### PR TITLE
lotus-utils comes from gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,8 @@ source 'https://rubygems.org'
 gemspec
 
 if !ENV['TRAVIS']
-  gem 'byebug',      require: false, platforms: :ruby if RUBY_VERSION == '2.1.1'
-  gem 'yard',        require: false
-  gem 'lotus-utils', require: false, path: '../lotus-utils'
-else
-  gem 'lotus-utils'
+  gem 'byebug', require: false, platforms: :ruby if RUBY_VERSION == '2.1.1'
+  gem 'yard', require: false
 end
 
 gem 'haml',      require: false


### PR DESCRIPTION
It might be the case that you would keep the `lotus-utils` local path in your Gemfile but this prevented me from pulling this down locally and being able to run the specs
