### PR TITLE
Support arguments for methods inside templates

### DIFF
--- a/lib/lotus/view/rendering/scope.rb
+++ b/lib/lotus/view/rendering/scope.rb
@@ -33,9 +33,9 @@ module Lotus
         end
 
         protected
-        def method_missing(m)
+        def method_missing(m, *args)
           if @view.respond_to?(m)
-            @view.__send__ m
+            @view.__send__ m, *args
           elsif @locals.key?(m)
             @locals[m]
           else

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -6,6 +6,14 @@ class RenderView
   include Lotus::View
 end
 
+class RenderViewMethodWithArgs
+  include Lotus::View
+
+  def planet(name)
+    name.to_s
+  end
+end
+
 class JsonRenderView
   include Lotus::View
   format :json

--- a/test/fixtures/templates/render_view_method_with_args.html.erb
+++ b/test/fixtures/templates/render_view_method_with_args.html.erb
@@ -1,0 +1,2 @@
+<h1>Hello, <%= planet(:earth) %>!</h1>
+

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -25,6 +25,12 @@ describe Lotus::View do
       rendered.must_match %(<h1>Man on the Moon!</h1>)
     end
 
+    describe 'calling an action method from the template' do
+      it 'can call with multiple arguments' do
+        RenderViewMethodWithArgs.render({format: :html}).must_include %(<h1>Hello, earth!</h1>)
+      end
+    end
+
     it 'binds given locals to the rendering context' do
       article = OpenStruct.new(title: 'Hello')
 


### PR DESCRIPTION
Methods inside templates could not have any arguments without causing an error.  Because of that, it would be impossible to write a function like:

`<%= link_to "google", "http://google.com" %>`

beceause lotus would error out with an `ArgumentError`.  The fix is to ensure method_missing passes any arguments along to the view instance.
