### PR TITLE
Don't bind blocks if not necessary

### DIFF
--- a/lib/lotus/view/rendering/null_template.rb
+++ b/lib/lotus/view/rendering/null_template.rb
@@ -70,8 +70,8 @@ module Lotus
         #
         # @see Lotus::Layout#render
         # @see Lotus::View::Rendering#render
-        def render(scope, locals = {}, &blk)
-          blk.call
+        def render(scope, locals = {})
+          yield
         end
       end
     end


### PR DESCRIPTION
Having this benchmark:

```
require 'lotus/view'
require 'benchmark/ips'

module Lotus
  module View
    module Rendering
      class NullTemplate
        def fast_render(scope, locals = {})
          yield
        end
      end
    end
  end
end


template = Lotus::View::Rendering::NullTemplate.new

Benchmark.ips do |x|
  x.report("blk.call") do
    template.render nil do
    end
  end
  x.report("yield") do
    template.fast_render nil do
    end
  end
end
```

yields such results:

```
Calculating -------------------------------------
            blk.call     87147 i/100ms
               yield    155453 i/100ms
-------------------------------------------------
            blk.call  1516789.7 (±6.6%) i/s -    7581789 in   5.019669s
               yield  5565781.8 (±1.2%) i/s -   27826087 in   5.000213s
```

Therefore I replaced unneeded blk.call with yield. I found no documentation, which would need an update.
