### PR TITLE
Renaming .dupe to .dup

### DIFF
--- a/lib/lotus/view.rb
+++ b/lib/lotus/view.rb
@@ -87,7 +87,7 @@ module Lotus
     #   require 'lotus/view'
     #
     #   module MyApp
-    #     View = Lotus::View.dupe
+    #     View = Lotus::View.dup
     #   end
     #
     #   MyApp::View == Lotus::View # => false
@@ -103,11 +103,11 @@ module Lotus
     #   end
     #
     #   module MyApp
-    #     View = Lotus::View.dupe
+    #     View = Lotus::View.dup
     #   end
     #
     #   module MyApi
-    #     View = Lotus::View.dupe
+    #     View = Lotus::View.dup
     #     View.configure do
     #       root '/another/root'
     #     end
@@ -116,9 +116,10 @@ module Lotus
     #   Lotus::View.configuration.root # => #<Pathname:/path/to/root>
     #   MyApp::View.configuration.root # => #<Pathname:/path/to/root>
     #   MyApi::View.configuration.root # => #<Pathname:/another/root>
-    def self.dupe
-      dup.tap do |duplicated|
+    def self.dup
+      super.tap do |duplicated|
         duplicated.configuration = configuration.duplicate
+        yield(duplicated) if block_given?
       end
     end
 
@@ -169,7 +170,7 @@ module Lotus
     #   # it's equivalent to:
     #
     #   module MyApp
-    #     View   = Lotus::View.dupe
+    #     View   = Lotus::View.dup
     #     Layout = Lotus::Layout.dup
     #
     #     module Views
@@ -225,7 +226,7 @@ module Lotus
     #   Lotus::View.configuration.root # => #<Pathname:.>
     #   MyApp::View.configuration.root # => #<Pathname:/path/to/root>
     def self.duplicate(mod, views = 'Views', &blk)
-      dupe.tap do |duplicated|
+      dup do |duplicated|
         mod.module_eval %{ module #{ views }; end } if views
         mod.module_eval %{ Layout = Lotus::Layout.dup }
 

--- a/test/view_test.rb
+++ b/test/view_test.rb
@@ -106,7 +106,7 @@ describe Lotus::View do
     end
   end
 
-  describe '.dupe' do
+  describe '.dup' do
     before do
       Lotus::View.class_eval do
         configure do
@@ -114,7 +114,7 @@ describe Lotus::View do
         end
       end
 
-      DuplicatedView = Lotus::View.dupe
+      DuplicatedView = Lotus::View.dup
 
       @framework_config  = Lotus::View.configuration
       @duplicated_config = DuplicatedView.configuration


### PR DESCRIPTION
With the presence of Lotus::View.dup, .dupe, and .duplicate things
were a bit confusing. The solution is to assume that .dup will come
with a configuration duplication.

Closes #35
