### PR TITLE
Added exception if layout isn't found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.gem
 *.rbc
 .bundle

--- a/lib/lotus/view/rendering/layout_registry.rb
+++ b/lib/lotus/view/rendering/layout_registry.rb
@@ -4,6 +4,16 @@ require 'lotus/view/rendering/templates_finder'
 module Lotus
   module View
     module Rendering
+      # Missing template layout error
+      #
+      # This is raised at the runtime when Lotus::Layout cannot find it's template.
+      #
+      # @since x.x.x
+      class MissingTemplateLayoutError < ::StandardError
+        def initialize(template)
+          super("Can't find layout template '#{ template }'")
+        end
+      end
       # Holds the references of all the registered layouts.
       # As now the registry is unique at the level of the framework.
       #
@@ -48,6 +58,7 @@ module Lotus
           templates.each do |template|
             merge! template.format => template
           end
+          self.any? or raise MissingTemplateLayoutError.new(@view)
         end
 
         def templates

--- a/test/fixtures/templates/configuration.html.erb
+++ b/test/fixtures/templates/configuration.html.erb
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title><%= title %></title>
+  </head>
+
+  <body>
+    <%= render partial: 'shared/sidebar' %>
+    <%= yield %>
+  </body>
+</html>

--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -8,6 +8,19 @@ describe Lotus::Layout do
     end
   end
 
+  it "raise error if template isn't found" do
+    Lotus::View.unload!
+
+    class MissingLayout
+      include Lotus::Layout
+    end
+
+    error = -> {
+      Lotus::View.load!
+    }.must_raise(Lotus::View::Rendering::MissingTemplateLayoutError)
+    error.message.must_include "Can't find layout template 'MissingLayout'"
+  end
+
   it 'concrete methods are available in layout template' do
     rendered = Store::Views::Home::Index.render(format: :html)
     rendered.must_match %(script)


### PR DESCRIPTION
I don't know if this first approach is valid, I want to discuss with you.

I have created a tree directories: 
- tmp/app/templates/posts/index.html.erb
- tmp/app/templates/default.html.erb

``` ruby
require 'lotus/view'

class DefaultLayout
  include Lotus::Layout

  def page_title
    'Title:'
  end
end

module Posts
  class Index
    include Lotus::View
    layout :default
  end
end

Lotus::View.configure do
  root 'tmp/app/templates'
end

Lotus::View.load!
Posts::Index.render(format: :html)
```

With this implementation all works fine, if I rename my default.index.html layout to 1234default.index.html (for example). Now I have the MissingTemplateError error created.

Is this approach correct?
