### PR TITLE
Fix SimpleCov deprecation message

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ if ENV['COVERAGE'] == 'true'
   require 'simplecov'
   require 'coveralls'
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     Coveralls::SimpleCov::Formatter
   ]


### PR DESCRIPTION
This avoids the following deprecation message:

```
test/test_helper.rb:8:in `<top (required)>': [DEPRECATION] ::[] is
deprecated. Use ::new instead.
```