### PR TITLE
Try local

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,10 +472,12 @@ As per convention, layout templates are located under `Hanami::View.root` or `Ap
 
 ### Optional Content
 
-If we want to render optional contents such as sidebar links or page specific javascripts, we can use `#content`
+#### Optional View Methods
+
+If we want to render optional contents such as sidebar links or page specific javascripts, we can use `#local`
 It accepts a key that represents a method that should be available within the rendering context.
 That context is made of the locals, and the methods that view and layout respond to.
-If the context can't dispatch that method, it returns `nil`.
+If the context can't dispatch that method, it returns returns a null object (`Hanami::View::Rendering::NullLocal`).
 
 Given the following layout template.
 
@@ -485,14 +487,14 @@ Given the following layout template.
   <!-- ... -->
   <body>
     <!-- ... -->
-    <%= content :footer %>
+    <%= local :footer %>
   </body>
 </html>
 ```
 
 We have two views, one responds to `#footer` (`Products::Show`) and the other doesn't (`Products::Index`).
-When the first is rendered, `content` gives back the returning value of `#footer`.
-In the other case, `content` returns `nil`.
+When the first is rendered, `local` gives back the returning value of `#footer`.
+In the other case, `local` returns a null object (`Hanami::View::Rendering::NullLocal`).
 
 ```ruby
 module Products
@@ -509,6 +511,20 @@ module Products
   end
 end
 ```
+
+#### Optional Locals
+
+If we want to show announcements to our customers, but we want only load them from the database if there is something to show.
+This is an optional local.
+
+```erb
+<% if local(:announcement).show? %>
+  <h2><%= announcement.message %></h2>
+<% end %>
+```
+
+The first line is safely evaluated in all the cases: if announcement is present or not.
+In case we enter the `if` statement, we're sure we can safely reference that object.
 
 ### Presenters
 

--- a/lib/hanami/view/rendering.rb
+++ b/lib/hanami/view/rendering.rb
@@ -1,5 +1,6 @@
 require 'hanami/view/rendering/registry'
 require 'hanami/view/rendering/scope'
+require 'hanami/view/rendering/null_local'
 
 module Hanami
   module View
@@ -102,6 +103,20 @@ module Hanami
         #   view.render # => {title: ...}
         def render
           layout.render
+        end
+
+        # Return a local for the corresponding key, otherwise it returns a null object
+        #
+        # @return [Objeect,Hanami::View::Rendering::NullLocal] the returning value
+        #
+        # @since x.x.x
+        #
+        # @example
+        #   <% if local(:plan).overdue? %>
+        #     <h2>Your plan is overdue.</h2>
+        #   <% end %>
+        def local(key)
+          locals.fetch(key) { NullLocal.new(key) }
         end
 
         protected

--- a/lib/hanami/view/rendering.rb
+++ b/lib/hanami/view/rendering.rb
@@ -105,7 +105,8 @@ module Hanami
           layout.render
         end
 
-        # Return a local for the corresponding key, otherwise it returns a null object
+        # It tries to invoke a method for the view or a local for the given key.
+        # If the lookup fails, it returns a null object.
         #
         # @return [Objeect,Hanami::View::Rendering::NullLocal] the returning value
         #
@@ -116,7 +117,11 @@ module Hanami
         #     <h2>Your plan is overdue.</h2>
         #   <% end %>
         def local(key)
-          locals.fetch(key) { NullLocal.new(key) }
+          if respond_to?(key)
+            __send__(key)
+          else
+            locals.fetch(key) { NullLocal.new(key) }
+          end
         end
 
         protected

--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -124,6 +124,7 @@ module Hanami
         # @return [String,NilClass] returning content if scope respond to the
         #   requested method
         #
+        # @deprecated Use {#local} instead
         # @since 0.4.1
         #
         # @example
@@ -183,15 +184,15 @@ module Hanami
         #     <!-- ... -->
         #     <body>
         #       <!-- ... -->
-        #       <%= content :footer %>
+        #       <%= local :footer %>
         #     </body>
         #   </html>
         #
         #   # Case 1:
-        #   #   Products::Index doesn't respond to #footer, content will return nil
+        #   #   Products::Index doesn't respond to #footer, local will return nil
         #   #
         #   # Case 2:
-        #   #   Products::Show responds to #footer, content will send back
+        #   #   Products::Show responds to #footer, local will send back
         #   #     #footer returning value
         #
         #   module Products

--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -1,4 +1,6 @@
+require 'hanami/view/rendering/null_local'
 require 'hanami/utils/escape'
+require 'hanami/utils/deprecation'
 
 module Hanami
   module View
@@ -157,7 +159,60 @@ module Hanami
         #     end
         #   end
         def content(key)
+          Utils::Deprecation.new("#content is deprecated, please use #local")
           __send__(key) if respond_to?(key)
+        end
+
+        # It tries to invoke a method for the view or a local for the given key.
+        # If the lookup fails, it returns a null object.
+        #
+        # @return [Objeect,Hanami::View::Rendering::NullLocal] the returning value
+        #
+        # @since x.x.x
+        #
+        # @example Safe method navigation
+        #   <% if local(:plan).overdue? %>
+        #     <h2>Your plan is overdue.</h2>
+        #   <% end %>
+        #
+        # @example Optional Contents
+        #   # Given the following layout template
+        #
+        #   <!doctype HTML>
+        #   <html>
+        #     <!-- ... -->
+        #     <body>
+        #       <!-- ... -->
+        #       <%= content :footer %>
+        #     </body>
+        #   </html>
+        #
+        #   # Case 1:
+        #   #   Products::Index doesn't respond to #footer, content will return nil
+        #   #
+        #   # Case 2:
+        #   #   Products::Show responds to #footer, content will send back
+        #   #     #footer returning value
+        #
+        #   module Products
+        #     class Index
+        #       include Hanami::View
+        #     end
+        #
+        #     class Show
+        #       include Hanami::View
+        #
+        #       def footer
+        #         "contents for footer"
+        #       end
+        #     end
+        #   end
+        def local(key)
+          if respond_to?(key)
+            __send__(key)
+          else
+            locals.fetch(key) { NullLocal.new(key) }
+          end
         end
 
         # Implements "respond to" logic

--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -1,5 +1,4 @@
 require 'hanami/utils/escape'
-require 'hanami/view/rendering/null_local'
 
 module Hanami
   module View
@@ -112,20 +111,6 @@ module Hanami
         # @since 0.1.0
         def locals
           @locals || @scope.locals
-        end
-
-        # Return a local for the corresponding key, otherwise it returns a null object
-        #
-        # @return [Objeect,Hanami::View::Rendering::NullLocal] the returning value
-        #
-        # @since x.x.x
-        #
-        # @example
-        #   <% if local(:plan).overdue? %>
-        #     <h2>Your plan is overdue.</h2>
-        #   <% end %>
-        def local(key)
-          locals.fetch(key) { NullLocal.new(key) }
         end
 
         # Returns a content for the given key, by trying to invoke on the current

--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -1,4 +1,5 @@
 require 'hanami/utils/escape'
+require 'hanami/view/rendering/null_local'
 
 module Hanami
   module View
@@ -111,6 +112,20 @@ module Hanami
         # @since 0.1.0
         def locals
           @locals || @scope.locals
+        end
+
+        # Return a local for the corresponding key, otherwise it returns a null object
+        #
+        # @return [Objeect,Hanami::View::Rendering::NullLocal] the returning value
+        #
+        # @since x.x.x
+        #
+        # @example
+        #   <% if local(:plan).overdue? %>
+        #     <h2>Your plan is overdue.</h2>
+        #   <% end %>
+        def local(key)
+          locals.fetch(key) { NullLocal.new(key) }
         end
 
         # Returns a content for the given key, by trying to invoke on the current

--- a/lib/hanami/view/rendering/null_local.rb
+++ b/lib/hanami/view/rendering/null_local.rb
@@ -7,7 +7,7 @@ module Hanami
       #
       # @since x.x.x
       #
-      # @see Hanami::View::Rendering::LayoutScope
+      # @see Hanami::View::Rendering#local
       class NullLocal < Utils::BasicObject
         # @since x.x.x
         # @api private
@@ -16,13 +16,33 @@ module Hanami
         end
 
         # @since x.x.x
-        # @api private
-        def method_missing(*)
+        def all?
+          false
+        end
+
+        # @since x.x.x
+        def any?
+          false
+        end
+
+        # @since x.x.x
+        def empty?
+          true
         end
 
         # @since x.x.x
         def nil?
           true
+        end
+
+        # @since x.x.x
+        # @api private
+        def method_missing(m, *)
+          if m.match(/\?\z/)
+            false
+          else
+            self.class.new("#{ @local }.#{ m }")
+          end
         end
 
         private

--- a/lib/hanami/view/rendering/null_local.rb
+++ b/lib/hanami/view/rendering/null_local.rb
@@ -11,6 +11,10 @@ module Hanami
       class NullLocal < Utils::BasicObject
         # @since x.x.x
         # @api private
+        TO_STR = "".freeze
+
+        # @since x.x.x
+        # @api private
         def initialize(local)
           @local = local
         end
@@ -33,6 +37,12 @@ module Hanami
         # @since x.x.x
         def nil?
           true
+        end
+
+        # @since x.x.x
+        # @api private
+        def to_str
+          TO_STR
         end
 
         # @since x.x.x

--- a/lib/hanami/view/rendering/null_local.rb
+++ b/lib/hanami/view/rendering/null_local.rb
@@ -1,0 +1,44 @@
+require 'hanami/utils/basic_object'
+
+module Hanami
+  module View
+    module Rendering
+      # Null local
+      #
+      # @since x.x.x
+      #
+      # @see Hanami::View::Rendering::LayoutScope
+      class NullLocal < Utils::BasicObject
+        # @since x.x.x
+        # @api private
+        def initialize(local)
+          @local = local
+        end
+
+        # @since x.x.x
+        # @api private
+        def method_missing(*)
+        end
+
+        # @since x.x.x
+        def nil?
+          true
+        end
+
+        private
+
+        # @since x.x.x
+        # @api private
+        def respond_to_missing?(method_name, include_all)
+          true
+        end
+
+        # @since x.x.x
+        # @api private
+        def __inspect
+          " :#{ @local }"
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -139,7 +139,7 @@ module Articles
     include Hanami::View
 
     def errors
-      {}
+      local(:result).errors
     end
   end
 
@@ -148,7 +148,7 @@ module Articles
     template 'articles/new'
 
     def errors
-      {title: 'Title is required'}
+      result.errors
     end
   end
 

--- a/test/fixtures/templates/application.html.erb
+++ b/test/fixtures/templates/application.html.erb
@@ -4,6 +4,10 @@
   </head>
 
   <body>
+    <% if local(:plan).overdue? %>
+      <h2>Your plan is overdue.</h2>
+    <% end %>
+
     <%= render partial: 'shared/sidebar' %>
     <%= yield %>
   </body>

--- a/test/fixtures/templates/dashboard/index.html.erb
+++ b/test/fixtures/templates/dashboard/index.html.erb
@@ -1,2 +1,6 @@
 <h1>Map</h1>
 <h2><%= map.count %> locations</h2>
+
+<% if local(:annotations).written? %>
+  <h3>Annotations</h3>
+<% end %>

--- a/test/fixtures/templates/store/templates/store.html.erb
+++ b/test/fixtures/templates/store/templates/store.html.erb
@@ -3,11 +3,12 @@
   <head>
     <title>Store</title>
     <%= javascript_tag 'application' %>
-    <%= content :head %>
+    <%= local :head %>
+    <%= content :foo %>
   </head>
 
   <body>
     <%= yield %>
-    <%= content :footer %>
+    <%= local :footer %>
   </body>
 </html>

--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -26,31 +26,54 @@ describe Hanami::Layout do
   end
 
   it 'concrete methods are available in layout template' do
-    rendered = Store::Views::Home::Index.render(format: :html)
-    rendered.must_match %(script)
-    rendered.must_match %(yeah)
+    with_silenced_deprecation do
+      rendered = Store::Views::Home::Index.render(format: :html)
+      rendered.must_match %(script)
+      rendered.must_match %(yeah)
+    end
   end
 
   it 'methods defined in layout are available from the view' do
-    rendered = Store::Views::Home::Index.render(format: :html)
-    rendered.must_match %(Joe Blogs)
+    with_silenced_deprecation do
+      rendered = Store::Views::Home::Index.render(format: :html)
+      rendered.must_match %(Joe Blogs)
+    end
   end
 
   it 'renders content to return value from view' do
-    rendered = Store::Views::Products::Show.render(format: :html)
-    rendered.must_match %(Product)
-    rendered.must_match %(<script src="/javascripts/product-tracking.js"></script>)
+    with_silenced_deprecation do
+      rendered = Store::Views::Products::Show.render(format: :html)
+      rendered.must_match %(Product)
+      rendered.must_match %(<script src="/javascripts/product-tracking.js"></script>)
+    end
   end
 
   it 'renders content to return value from layout' do
-    rendered = Store::Views::Products::Show.render(format: :html)
-    rendered.must_match %(Product)
-    rendered.must_match %(<meta name="hanamirb-version" content="0.3.1">)
+    with_silenced_deprecation do
+      rendered = Store::Views::Products::Show.render(format: :html)
+      rendered.must_match %(Product)
+      rendered.must_match %(<meta name="hanamirb-version" content="0.3.1">)
+    end
+  end
+
+  it 'deprecates #content' do
+    _, err = capture_io do
+      Store::Views::Products::Show.render(format: :html)
+    end
+
+    err.must_match "#content is deprecated, please use #local"
   end
 
   describe 'disable layout in view' do
     it 'return NullLayout' do
       DisabledLayoutView.layout.must_equal Hanami::View::Rendering::NullLayout
     end
+  end
+
+  private
+
+  require 'hanami/utils/io'
+  def with_silenced_deprecation(&blk)
+    Hanami::Utils::IO.silence_warnings(&blk)
   end
 end

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -91,8 +91,9 @@ describe Hanami::View do
 
     it 'renders different template, as specified by DSL' do
       article = OpenStruct.new(title: 'Bonjour')
+      result  = OpenStruct.new(errors: {title: 'Title is required'})
 
-      rendered = Articles::Create.render(format: :html, article: article)
+      rendered = Articles::Create.render(format: :html, article: article, result: result)
       rendered.must_match %(<h1>New Article</h1>)
       rendered.must_match %(<h2>Errors</h2>)
     end

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -120,6 +120,21 @@ describe Hanami::View do
       rendered.must_match %(<h2>2 locations</h2>)
     end
 
+    it 'safely ignores missing locals' do
+      map = Map.new(['Rome', 'Cambridge'])
+
+      rendered = Dashboard::Index.render(format: :html, map: map)
+      rendered.wont_match %(<h3>Annotations</h3>)
+    end
+
+    it 'uses optional locals, if present' do
+      map         = Map.new(['Rome', 'Cambridge'])
+      annotations = OpenStruct.new(written?: true)
+
+      rendered = Dashboard::Index.render(format: :html, annotations: annotations, map: map)
+      rendered.must_match %(<h3>Annotations</h3>)
+    end
+
     it 'renders a partial' do
       article = OpenStruct.new(title: nil)
 
@@ -193,6 +208,21 @@ describe Hanami::View do
         rendered.must_match %(<h1>A Wonderful Day!</h1>)
         rendered.must_match %(<html>)
         rendered.must_match %(<title>Title: articles</title>)
+      end
+
+      it 'safely ignores missing locals' do
+        articles = [ OpenStruct.new(title: 'A Wonderful Day!') ]
+
+        rendered = Articles::Index.render(format: :html, articles: articles)
+        rendered.wont_match %(<h2>Your plan is overdue.</h2>)
+      end
+
+      it 'uses optional locals, if present' do
+        articles = [ OpenStruct.new(title: 'A Wonderful Day!') ]
+        plan     =   OpenStruct.new(overdue?: true)
+
+        rendered = Articles::Index.render(format: :html, plan: plan, articles: articles)
+        rendered.must_match %(<h2>Your plan is overdue.</h2>)
       end
     end
   end

--- a/test/view/rendering/null_local_test.rb
+++ b/test/view/rendering/null_local_test.rb
@@ -5,12 +5,31 @@ describe Hanami::View::Rendering::NullLocal do
     @null = Hanami::View::Rendering::NullLocal.new(:result)
   end
 
-  it 'does not complain for uknown sent messages' do
-    @null.foo.must_be_nil
+  it 'does not complain for unknown sent messages' do
+    actual = @null.foo
+
+    actual.must_be_instance_of(Hanami::View::Rendering::NullLocal)
+    actual.inspect.must_match ":result.foo"
+  end
+
+  it 'returns false to all?' do
+    @null.all?.must_equal false
+  end
+
+  it 'returns false to any?' do
+    @null.any?.must_equal false
+  end
+
+  it 'returns true to empty?' do
+    @null.empty?.must_equal true
   end
 
   it 'returns true to nil?' do
-    assert @null.nil?, "Expect #{ @null } to be #nil?"
+    @null.nil?.must_equal true
+  end
+
+  it 'returns false to any method ending with question mark' do
+    @null.downloadable?.must_equal false
   end
 
   it 'always returns true for respond_to? check' do

--- a/test/view/rendering/null_local_test.rb
+++ b/test/view/rendering/null_local_test.rb
@@ -12,6 +12,10 @@ describe Hanami::View::Rendering::NullLocal do
     actual.inspect.must_match ":result.foo"
   end
 
+  it 'returns empty string for to_str' do
+    @null.to_str.must_equal ''
+  end
+
   it 'returns false to all?' do
     @null.all?.must_equal false
   end

--- a/test/view/rendering/null_local_test.rb
+++ b/test/view/rendering/null_local_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+describe Hanami::View::Rendering::NullLocal do
+  before do
+    @null = Hanami::View::Rendering::NullLocal.new(:result)
+  end
+
+  it 'does not complain for uknown sent messages' do
+    @null.foo.must_be_nil
+  end
+
+  it 'returns true to nil?' do
+    assert @null.nil?, "Expect #{ @null } to be #nil?"
+  end
+
+  it 'always returns true for respond_to? check' do
+    @null.respond_to?(:bar).must_equal true
+  end
+
+  it 'contains the name of the local in #inspect' do
+    @null.inspect.must_match ":result"
+  end
+end


### PR DESCRIPTION
## Feature

Introducing `#local` as a public method that is available in views, layouts and templates.
In case we want to safely navigate methods or locals, we can use this new method.

Here's some examples.

### Optional Content

Let's say we want to render optional contents for footer, for instance per page javascripts.

```erb
# apps/web/templates/application.html.erb
<!doctype HTML>
<html>
  <!-- ... -->
  <body>
    <!-- ... -->
    <%= local :footer %>
  </body>
</html>
```

We have one view that **DOES NOT** respond to `#footer`

```ruby
# apps/web/views/products/index.rb
module Web::Views::Products
  class Index
    include Web::View
  end
end
```

And another view that **DOES** respond to `#footer`.

```ruby
# apps/web/views/products/show.rb
module Web::Views::Products
  class Show
    include Web::View

    def footer
      javascript 'product'
    end
  end
end
```

When the first view is rendered, `local :footer` is completely ignored and that interpolation returns a blank string. When the second one is rendered, because it respond to `#footer`, that method is invoked and the returning value is used for the interpolation (a `<script>` tag, in the example).

### Optional Locals

We have a view that renders a form.
We may want to show validation errors, only if we have a `result` local that carries on the errors.

```ruby
# apps/web/views/products/new.rb
module Web::Views::Products
  class New
    include Web::View

    def error
      local(:result).error
    end
  end
end
```

```erb
<% unless error.nil? %>
  <%= error.message %>
<% end %>
```

### Safe Locals Navigation

We have announcements to show in our UI.
They may or may not be loaded from the database ad passed to the view.

```erb
<% if local(:announcement).display? %>
  <%= announcement.message %>
<% end %>
```

## Deprecation

We have a similar API that this PR aims to deprecate: `#content`.
The problem with content is that it doesn't allow "Safe Navigation" feature.

For instance

```erb
<% if content(:announcement).display? %>
  <%= announcement.message %>
<% end %>
```

The first line would raise a `NoMethodError`, because `#content` returns `nil` in case the lookup fails. On the other hand, `#local` returns a null object that allows Safe Navigation.

---

/cc @hanami/core-team @hanami/contributors 