### PR TITLE
Fix Nested Resource support for templates

### DIFF
--- a/lib/hanami/view/rendering/templates_finder.rb
+++ b/lib/hanami/view/rendering/templates_finder.rb
@@ -79,7 +79,18 @@ module Hanami
         # @api private
         # @since 0.4.3
         def _find(lookup = search_path)
-          Dir.glob( "#{ [root, lookup, template_name].join(separator) }.#{ format }.#{ engines }" )
+          primary_templates = templates_in_base_path
+          if primary_templates.none?
+            Dir.glob( "#{ [root, lookup, template_name].join(separator) }.#{ format }.#{ engines }" )
+          else
+            primary_templates
+          end
+        end
+
+        # @api private
+        # @since 0.7.0
+        def templates_in_base_path
+          Dir.glob("#{ [root, template_name].join(separator) }.#{ format }.#{ engines }")
         end
 
         # @api private

--- a/lib/hanami/view/rendering/templates_finder.rb
+++ b/lib/hanami/view/rendering/templates_finder.rb
@@ -78,19 +78,23 @@ module Hanami
 
         # @api private
         # @since 0.4.3
+        #
+        # Searches first for files at `../templates/articles/index.*.*`
+        # If none are found, falls back to recursive search in `../templates/**/articles/index.*.*`
+        #
         def _find(lookup = search_path)
-          primary_templates = templates_in_base_path
-          if primary_templates.none?
-            Dir.glob( "#{ [root, lookup, template_name].join(separator) }.#{ format }.#{ engines }" )
+          base_path = templates_path(root, template_name)
+          if base_path.none?
+            templates_path(root, lookup, template_name)
           else
-            primary_templates
+            base_path
           end
         end
 
         # @api private
         # @since 0.7.0
-        def templates_in_base_path
-          Dir.glob("#{ [root, template_name].join(separator) }.#{ format }.#{ engines }")
+        def templates_path(*parts)
+          Dir.glob("#{ parts.join(separator) }.#{ format }.#{ engines }")
         end
 
         # @api private

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -115,6 +115,19 @@ end
 class GlobalLayout
 end
 
+module Members
+  module Articles
+    class Index
+      include Hanami::View
+      layout :application
+
+      def title
+        "#{ layout.title } articles"
+      end
+    end
+  end
+end
+
 module Articles
   class Index
     include Hanami::View

--- a/test/fixtures/templates/members/articles/index.html.erb
+++ b/test/fixtures/templates/members/articles/index.html.erb
@@ -1,0 +1,4 @@
+<h1> All Articles By This Member: </h1>
+<% articles.each do |article| %>
+  <h1>Wrong Article Template</h1>
+<% end %>

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -54,6 +54,10 @@ describe Hanami::View do
       rendered = Articles::Index.render(format: :html, articles: articles)
       rendered.wont_match %(<h1>Wrong Article Template</h1>)
       rendered.must_match %(<h1>Man on the Moon!</h1>)
+
+      rendered = Members::Articles::Index.render(format: :html, articles: articles)
+      rendered.must_match %(<h1>Wrong Article Template</h1>)
+      rendered.wont_match %(<h1>Man on the Moon!</h1>)
     end
 
     describe 'calling an action method from the template' do

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -47,6 +47,15 @@ describe Hanami::View do
       rendered.must_match %(<h1>Man on the Moon!</h1>)
     end
 
+    # this test was added to show that ../templates/members/articles/index.html.erb interferres with the normal behavior
+    it 'renders the correct template when a subdirectory also exists' do
+      articles = [ OpenStruct.new(title: 'Man on the Moon!') ]
+
+      rendered = Articles::Index.render(format: :html, articles: articles)
+      rendered.wont_match %(<h1>Wrong Article Template</h1>)
+      rendered.must_match %(<h1>Man on the Moon!</h1>)
+    end
+
     describe 'calling an action method from the template' do
       it 'can call with multiple arguments' do
         RenderViewMethodWithArgs.render({format: :html}).must_include %(<h1>Hello, earth!</h1>)


### PR DESCRIPTION
If `../templates/members/articles/index.html.erb` and `../templates/articles/index.html.erb` both exist, then the template finder will find the former instead of the latter when grabbing the file for a Articles::Index View class. 

re: issue https://github.com/hanami/view/issues/100