### PR TITLE
Maintain the original method visibility on Module#prepend

### DIFF
--- a/lib/hanami/view/escape.rb
+++ b/lib/hanami/view/escape.rb
@@ -165,8 +165,9 @@ module Hanami
       # @since 0.4.0
       # @api private
       def method_added(method_name)
+        visibility = :public
         visibility = :private if private_method_defined? method_name
-        visibility ||= :protected if protected_method_defined? method_name
+        visibility = :protected if protected_method_defined? method_name
 
         unless autoescape_methods[method_name]
           prepend Module.new {

--- a/lib/hanami/view/escape.rb
+++ b/lib/hanami/view/escape.rb
@@ -165,10 +165,13 @@ module Hanami
       # @since 0.4.0
       # @api private
       def method_added(method_name)
+        visibility = :private if private_method_defined? method_name
+        visibility ||= :protected if protected_method_defined? method_name
+
         unless autoescape_methods[method_name]
           prepend Module.new {
             module_eval %{
-              def #{ method_name }(*args, &blk); ::Hanami::View::Escape.html super; end
+              #{ visibility } def #{ method_name }(*args, &blk); ::Hanami::View::Escape.html super; end
             }
           }
 

--- a/test/escape_test.rb
+++ b/test/escape_test.rb
@@ -52,5 +52,6 @@ describe 'Escape' do
   it "does not alter the method visibility" do
     Users::Show.private_instance_methods.must_include(:private_username)
     Users::Show.protected_instance_methods.must_include(:protected_username)
+    Users::Show.public_instance_methods.must_include(:raw_username)
   end
 end

--- a/test/escape_test.rb
+++ b/test/escape_test.rb
@@ -31,7 +31,7 @@ describe 'Escape' do
   end
 
   it "doesn't interfer with other views" do
-    Users::Show.autoescape_methods.must_equal({custom: true, username: true, raw_username: true, book: true})
+    Users::Show.autoescape_methods.must_equal({custom: true, username: true, raw_username: true, book: true, protected_username: true, private_username: true})
     Users::Extra.autoescape_methods.must_equal({username: true})
   end
 
@@ -47,5 +47,10 @@ describe 'Escape' do
     json = Users::Show.render(format: :json, user: user)
 
     json.must_match %({"username":"L"})
+  end
+
+  it "does not alter the method visibility" do
+    Users::Show.private_instance_methods.must_include(:private_username)
+    Users::Show.protected_instance_methods.must_include(:protected_username)
   end
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -499,6 +499,17 @@ module Users
     def book
       _escape(locals[:book])
     end
+
+    protected
+
+    def protected_username
+      user.username
+    end
+
+    private
+    def private_username
+      user.username
+    end
   end
 
   class XmlShow < Show


### PR DESCRIPTION
This solves issue #102 where private and protected methods became public
on the prepended modules used for autoescaping.

I'm not that much happy with the code, but it works and isn't that ugly. =)

---

Closes #102 