### PR TITLE
Make second arg to Hanami::View initialize accept keyword arguments

### DIFF
--- a/lib/hanami/view/rendering.rb
+++ b/lib/hanami/view/rendering.rb
@@ -36,7 +36,7 @@ module Hanami
         #
         #   template = Hanami::View::Template.new('index.html.erb')
         #   view     = IndexView.new(template, {article: article})
-        def initialize(template, locals)
+        def initialize(template, **locals)
           @template = template
           @locals   = locals
           @scope    = Scope.new(self, @locals)

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -5,6 +5,24 @@ require 'ostruct'
 describe Hanami::View do
   reload_configuration!
 
+  describe 'initializing' do
+    before do
+      @view = Class.new do
+        include Hanami::View
+      end
+
+      @template = Hanami::View::Template.new(__dir__ + '/fixtures/templates/hello_world.html.erb')
+    end
+
+    it 'initializes view without keyword arguments' do
+      @view.new(@template).locals.must_equal Hash[]
+    end
+
+    it 'initializes view with keyword arguments' do
+      @view.new(@template, hello: 'world').locals.must_equal({hello: 'world'})
+    end
+  end
+
   describe 'rendering' do
     it 'renders a template' do
       HelloWorldView.render(format: :html).must_include %(<h1>Hello, World!</h1>)


### PR DESCRIPTION
Hi,

What do you think about this tiny change to `initialize` method of Hanami::View?

It doesn't change any behavior of `hanami-view` gem, but allows to integrate it with `dry-system` and `dry-auto_inject` gems. Since hanami is cooperating with dry-rb ecosystem, it could be useful I think. At least for me :)