### PR TITLE
Add error message for missing or unknown type passed to render

### DIFF
--- a/lib/hanami/view/errors.rb
+++ b/lib/hanami/view/errors.rb
@@ -26,7 +26,7 @@ module Hanami
 
     # Missing format error
     #
-    # This is raised at the runtime when rendering context lacks of the :format
+    # This is raised at the runtime when rendering context lacks the :format
     # key.
     #
     # @since 0.1.0
@@ -37,7 +37,7 @@ module Hanami
 
     # Missing template layout error
     #
-    # This is raised at the runtime when Hanami::Layout cannot find it's template.
+    # This is raised at the runtime when Hanami::Layout cannot find its template.
     #
     # @since 0.5.0
     class MissingTemplateLayoutError < Error
@@ -45,6 +45,21 @@ module Hanami
       # @api private
       def initialize(template)
         super("Can't find layout template '#{ template }'")
+      end
+    end
+
+    # Unknown or missing render type
+    #
+    # This is raised at the runtime when Hanami::Layout doesn't recognize the render type.
+    #
+    # @since X.X.X
+    class UnknownOrMissingRenderTypeLayoutError < Error
+      # @since X.X.X
+      # @api private
+      def initialize(known_types, supplied_options)
+        known_types_list = known_types.map{|t| "':#{t}'"}.join(', ')
+        supplied_options_list = supplied_options.keys.map{|t| "':#{t}'"}.join(', ')
+        super("Calls to `render` in a layout must include one of #{known_types_list}. Found #{supplied_options_list}.")
       end
     end
   end

--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -4,7 +4,12 @@ require 'hanami/utils/escape'
 module Hanami
   module View
     module Rendering
-
+        
+      # List of render types that exactly one of must be included when calling `#render`. 
+      # For example, when calling `<%= render something: 'my_thing', locals: {} %>`,
+      # 'something' must be one of the values listed here.
+      # 
+      # @since X.X.X
       KNOWN_RENDER_TYPES = [:partial, :template]
 
       # Scope for layout rendering

--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -4,6 +4,9 @@ require 'hanami/utils/escape'
 module Hanami
   module View
     module Rendering
+
+      KNOWN_RENDER_TYPES = [:partial, :template]
+
       # Scope for layout rendering
       #
       # @since 0.1.0
@@ -87,6 +90,9 @@ module Hanami
         #   #
         #   # `user` will be available in the scope of the sidebar rendering
         def render(options)
+          if !KNOWN_RENDER_TYPES.any?{|render_type| options[render_type]}
+            ::Kernel.raise UnknownOrMissingRenderTypeLayoutError.new(KNOWN_RENDER_TYPES, options)
+          end
           renderer(options).render
         end
 

--- a/spec/unit/hanami/view/rendering/layout_scope_spec.rb
+++ b/spec/unit/hanami/view/rendering/layout_scope_spec.rb
@@ -82,8 +82,9 @@ RSpec.describe Hanami::View::Rendering::LayoutScope do
   describe '#render' do
     describe 'render with no known render type' do
       it 'raises UnknownOrMissingRenderTypeLayoutError' do
-        exception = -> { @scope.render(templte: "misspelled") }.must_raise Hanami::View::UnknownOrMissingRenderTypeLayoutError
-        exception.message.must_include "Calls to `render` in a layout must include one of ':partial', ':template'. Found ':templte'."
+        expect do
+          @scope.render(templte: "misspelled")
+        end.to raise_error(Hanami::View::UnknownOrMissingRenderTypeLayoutError, /Calls to `render` in a layout must include one of ':partial', ':template'. Found ':templte'./)
       end
     end
   end

--- a/spec/unit/hanami/view/rendering/layout_scope_spec.rb
+++ b/spec/unit/hanami/view/rendering/layout_scope_spec.rb
@@ -78,4 +78,14 @@ RSpec.describe Hanami::View::Rendering::LayoutScope do
       end
     end
   end
+
+  describe '#render' do
+    describe 'render with no known render type' do
+      it 'raises UnknownOrMissingRenderTypeLayoutError' do
+        exception = -> { @scope.render(templte: "misspelled") }.must_raise Hanami::View::UnknownOrMissingRenderTypeLayoutError
+        exception.message.must_include "Calls to `render` in a layout must include one of ':partial', ':template'. Found ':templte'."
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
If you accidentally do this:
```erb
<%= render templte: "shared/something", locals: {a: 1} %>
```
Instead of getting this error:

```
NoMethodError at 
undefined method `new' for nil:NilClass
```

You get:

```
Hanami::View::UnknownOrMissingRenderTypeLayoutError at 
Calls to `render` in a layout must include one of ':partial', ':template'. Found ':templte', ':locals'.
```

Closes #126 