### PR TITLE
Introduce Hanami::Layout#local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Hanami::View
 View layer for Hanami
 
+## v1.1.0.beta2 (unreleased)
+### Added
+- [Luca Guidi] Added `Hanami::Layout#local` to safely access locals from layouts
+
 ## v1.1.0.beta1 - 2017-08-11
 ### Fixed
 - [yjukaku] Raise `Hanami::View::UnknownRenderTypeError` when an argument different from `:template` or `:partial` is passed to `render`

--- a/lib/hanami/layout.rb
+++ b/lib/hanami/layout.rb
@@ -142,7 +142,7 @@ module Hanami
     # It tries to invoke a method for the view or a local for the given key.
     # If the lookup fails, it returns a null object.
     #
-    # @return [Objeect,Hanami::View::Rendering::NullLocal] the returning value
+    # @return [Object,Hanami::View::Rendering::NullLocal] the returning value
     #
     # @since 1.1.0
     #

--- a/lib/hanami/layout.rb
+++ b/lib/hanami/layout.rb
@@ -139,6 +139,27 @@ module Hanami
       template.render(@scope, &Proc.new{@rendered})
     end
 
+    # It tries to invoke a method for the view or a local for the given key.
+    # If the lookup fails, it returns a null object.
+    #
+    # @return [Objeect,Hanami::View::Rendering::NullLocal] the returning value
+    #
+    # @since 1.1.0
+    #
+    # @example Safe method navigation
+    #   class ApplicationLayout
+    #     include Hanami::Layout
+    #
+    #     def render_flash
+    #       return if local(:flash).nil?
+    #
+    #       # ...
+    #     end
+    #   end
+    def local(key)
+      @scope.local(key)
+    end
+
     protected
     # The template for the current format
     #

--- a/lib/hanami/view/rendering.rb
+++ b/lib/hanami/view/rendering.rb
@@ -110,7 +110,7 @@ module Hanami
         # It tries to invoke a method for the view or a local for the given key.
         # If the lookup fails, it returns a null object.
         #
-        # @return [Objeect,Hanami::View::Rendering::NullLocal] the returning value
+        # @return [Object,Hanami::View::Rendering::NullLocal] the returning value
         #
         # @since 0.7.0
         #

--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -131,7 +131,7 @@ module Hanami
         # It tries to invoke a method for the view or a local for the given key.
         # If the lookup fails, it returns a null object.
         #
-        # @return [Objeect,Hanami::View::Rendering::NullLocal] the returning value
+        # @return [Object,Hanami::View::Rendering::NullLocal] the returning value
         #
         # @since 0.7.0
         #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,10 +49,6 @@ Hanami::View.class_eval do
   extend Unloadable
 end
 
-unless ENV['TRAVIS']
-  require 'byebug'
-end
-
 Hanami::Utils::LoadPaths.class_eval do
   def include?(object)
     @paths.include?(object)

--- a/spec/support/fixtures/fixtures.rb
+++ b/spec/support/fixtures/fixtures.rb
@@ -425,6 +425,14 @@ module Store
       def user_name
         "Joe Blogs"
       end
+
+      def render_flash
+        return if local(:flash).nil?
+
+        local(:flash).map do |type, message|
+          %(<div class="flash-#{type}">#{message}</div>)
+        end.join("\n")
+      end
     end
 
     module Home

--- a/spec/support/fixtures/templates/store/templates/store.html.erb
+++ b/spec/support/fixtures/templates/store/templates/store.html.erb
@@ -7,6 +7,7 @@
   </head>
 
   <body>
+    <%= render_flash %>
     <%= yield %>
     <%= local :footer %>
   </body>

--- a/spec/unit/hanami/layout_spec.rb
+++ b/spec/unit/hanami/layout_spec.rb
@@ -47,6 +47,11 @@ RSpec.describe Hanami::Layout do
     expect(rendered).to match %(<meta name="hanamirb-version" content="0.3.1">)
   end
 
+  it 'renders optional content from layout' do
+    rendered = Store::Views::Products::Show.render(format: :html, flash: { notice: "Product successfully updated" })
+    expect(rendered).to match %(<div class="flash-notice">Product successfully updated</div>)
+  end
+
   describe 'disable layout in view' do
     it 'return NullLayout' do
       expect(DisabledLayoutView.layout).to eq Hanami::View::Rendering::NullLayout


### PR DESCRIPTION
To explain the need of this enhancement let me go straight with an example:

```ruby
# apps/web/views/application_layout.rb
module Web
  module Views
    class ApplicationLayout
      include Web::Layout

      def render_flash
        return if local(:flash).nil?

        local(:flash).map do |type, message|
          html.div(message, class: "flash-#{type}")
        end.join("\n")
      end
    end
  end
end
```

To be used like this:

```erb
# apps/web/templates/application.html.erb
<%= render_flash %>
```

---

Until now, `#local` was only accessible from the associated template. So we were forced to write the code only in this way:

```erb
# apps/web/templates/application.html.erb
<% unless local(:flash).nil? %>
  <% local(:flash).each do |type, message| %>
    <div class="flash-<%= type %>">
      <%= message %>
    </div>
  <% end %>
<% end %>
```

---

To me it was surprising we added `#local` only to the template, but not to the layout. I think there should be a parity between them.