### PR TITLE
properly respect format option in nested render() calls

### DIFF
--- a/lib/hanami/view/rendering/options.rb
+++ b/lib/hanami/view/rendering/options.rb
@@ -11,10 +11,12 @@ module Hanami
         # @since 1.1.1
         # @api private
         def self.build(options, locals, format)
+          puts options
           options.dup.tap do |opts|
-            opts[:format] = format
+            opts[:format] ||= format
             opts[:locals] = locals
-            opts[:locals].merge!(options.fetch(:locals) { ::Hash.new }).merge!(format: format)
+            opts[:locals].merge!(options.fetch(:locals) { ::Hash.new })
+            opts[:locals].merge!(format: opts.fetch(:format, format))
           end
         end
       end

--- a/spec/integration/partial_spec.rb
+++ b/spec/integration/partial_spec.rb
@@ -24,4 +24,10 @@ RSpec.describe 'Framework configuration' do
     rendered = App3::Views::Home::Index.render(format: :html, name: 'name')
     expect(rendered).to eq("View before, View name\nimplicit partial, View name\nother partial, View name\ndeep partial, View name\nexplicit partial, View partial\nother partial, View partial\ndeep partial, View partial\nView after, View name\n")
   end
+
+  it "Articles can render html partial within js template" do
+    article  = OpenStruct.new(title: "An Article")
+    rendered = Articles::New.render(format: :js, article: article)
+    expect(rendered).to eq(%[$("form").html("<form>\n  <input type=\"hidden\" name=\"secret\" value=\"23\" />\n  <input type=\"text\" name=\"article[title]\" value=\"An Article\" />\n</form>\n");\n])
+  end
 end

--- a/spec/support/fixtures/fixtures.rb
+++ b/spec/support/fixtures/fixtures.rb
@@ -152,6 +152,10 @@ module Articles
     end
   end
 
+  class JsNew < New
+    format :js
+  end
+
   class Create
     include Hanami::View
     template 'articles/new'

--- a/spec/support/fixtures/templates/articles/new.js.erb
+++ b/spec/support/fixtures/templates/articles/new.js.erb
@@ -1,0 +1,1 @@
+$("form").html("<%= render(partial: 'articles/form', format: :html, locals: { secret: 23 }) %>");


### PR DESCRIPTION
patched `Rendering::Options` to properly respect format option and not just overwrite it with the parent's format.

this will allow render(partial: "...", format: :html) inside a js template.

before:

```
$ bundle exec rspec ./spec/integration/partial_spec.rb:28
Run options: include {:locations=>{"./spec/integration/partial_spec.rb"=>[28]}}

Randomized with seed 61017

Framework configuration
  Articles can render js with html partial (FAILED - 1)

Failures:

  1) Framework configuration Articles can render js with html partial
     Failure/Error:
       raise MissingTemplateError.new(
         @options.fetch(:template) { @options.fetch(:partial, nil) },
         @options[:format]
       )

     Hanami::View::MissingTemplateError:
       Can't find template 'articles/form' for 'js' format.
     # ./lib/hanami/view/rendering/template.rb:61:in `raise_missing_template_error'
     # ./lib/hanami/view/rendering/template.rb:44:in `render'
     # ./lib/hanami/view/rendering/layout_scope.rb:102:in `render'
     # ./spec/support/fixtures/templates/articles/new.js.erb:1:in `block in singleton class'
     # ./spec/support/fixtures/templates/articles/new.js.erb:-6:in `instance_eval'
     # ./spec/support/fixtures/templates/articles/new.js.erb:-6:in `singleton class'
     # ./spec/support/fixtures/templates/articles/new.js.erb:-9:in `__tilt_70339778574300'
     # ./lib/hanami/view/template.rb:41:in `render'
     # ./lib/hanami/view/rendering.rb:140:in `rendered'
     # ./lib/hanami/view/rendering.rb:154:in `layout'
     # ./lib/hanami/view/rendering.rb:108:in `render'
     # ./lib/hanami/view/rendering.rb:259:in `render'
     # ./spec/integration/partial_spec.rb:30:in `block (2 levels) in <top (required)>'

Top 1 slowest examples (0.00046 seconds, 33.7% of total time):
  Framework configuration Articles can render js with html partial
    0.00046 seconds ./spec/integration/partial_spec.rb:28

Finished in 0.00136 seconds (files took 0.30349 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/integration/partial_spec.rb:28 # Framework configuration Articles can render js with html partial

Randomized with seed 61017
```

after:

```
$ bundle exec rspec ./spec/integration/partial_spec.rb:28
Run options: include {:locations=>{"./spec/integration/partial_spec.rb"=>[28]}}

Randomized with seed 33187

Framework configuration
  Articles can render html partial within js template

Top 1 slowest examples (0.0011 seconds, 58.5% of total time):
  Framework configuration Articles can render html partial within js template
    0.0011 seconds ./spec/integration/partial_spec.rb:28

Finished in 0.00189 seconds (files took 0.3 seconds to load)
1 example, 0 failures

Randomized with seed 33187
```