### PR TITLE
Avoid Tilt warning about :disable_escape option

### DIFF
--- a/lib/hanami/view/template.rb
+++ b/lib/hanami/view/template.rb
@@ -7,11 +7,9 @@ module Hanami
     # @since 0.1.0
     class Template
       def initialize(template, encoding = Encoding::UTF_8)
-        default_options = {default_encoding: encoding}
+        options = {default_encoding: encoding}
 
-        options = default_options
-
-        if Tilt[template] != Tilt::HamlTemplate
+        if File.extname(template) == '.slim'
           # NOTE disable_escape: true is for Slim compatibility
           # See https://github.com/hanami/assets/issues/36
           options.merge!(disable_escape: true)

--- a/lib/hanami/view/template.rb
+++ b/lib/hanami/view/template.rb
@@ -7,9 +7,17 @@ module Hanami
     # @since 0.1.0
     class Template
       def initialize(template, encoding = Encoding::UTF_8)
-        # NOTE disable_escape: true is for Slim compatibility
-        # See https://github.com/hanami/assets/issues/36
-        @_template = Tilt.new(template, nil, default_encoding: encoding, disable_escape: true)
+        default_options = {default_encoding: encoding}
+
+        options = default_options
+
+        if Tilt[template] != Tilt::HamlTemplate
+          # NOTE disable_escape: true is for Slim compatibility
+          # See https://github.com/hanami/assets/issues/36
+          options.merge!(disable_escape: true)
+        end
+
+        @_template = Tilt.new(template, nil, options)
       end
 
       # Returns the format that the template handles.

--- a/spec/support/fixtures/templates/hello_world.html.slim
+++ b/spec/support/fixtures/templates/hello_world.html.slim
@@ -1,0 +1,1 @@
+h1 Hello, World!

--- a/spec/unit/hanami/view/template_spec.rb
+++ b/spec/unit/hanami/view/template_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Hanami::View::Template do
       end
 
       it 'sets :disable_escape to true with non-haml templates' do
-        template = Hanami::View::Template.new("#{TEMPLATE_ROOT_DIRECTORY}/hello_world.html.erb",)
+        template = Hanami::View::Template.new("#{TEMPLATE_ROOT_DIRECTORY}/hello_world.html.slim")
         expect(template.instance_variable_get(:@_template).__send__(:options)[:disable_escape]).to eq(true)
       end
     end

--- a/spec/unit/hanami/view/template_spec.rb
+++ b/spec/unit/hanami/view/template_spec.rb
@@ -14,5 +14,17 @@ RSpec.describe Hanami::View::Template do
       template = Hanami::View::Template.new("#{TEMPLATE_ROOT_DIRECTORY}/hello_world.html.erb", Encoding::ISO_8859_1)
       expect(template.instance_variable_get(:@_template).__send__(:default_encoding)).to eq Encoding::ISO_8859_1
     end
+
+    describe ':disable_escape option' do
+      it 'avoids the :disable_escape option with haml templates' do
+        template = Hanami::View::Template.new("#{TEMPLATE_ROOT_DIRECTORY}/contacts.html.haml")
+        expect(template.instance_variable_get(:@_template).__send__(:options)[:disable_escape]).to eq(nil)
+      end
+
+      it 'sets :disable_escape to true with non-haml templates' do
+        template = Hanami::View::Template.new("#{TEMPLATE_ROOT_DIRECTORY}/hello_world.html.erb",)
+        expect(template.instance_variable_get(:@_template).__send__(:options)[:disable_escape]).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
For HAML templates, this warning is shown for for each loaded template, which is noisy and annoying:
`Haml::TempleEngine: Option :disable_escape is invalid`

Another solution would be to only pass this option if we're dealing with a Slim template...