### PR TITLE
Ensure to safely use partial locals that can't be duplicated

### DIFF
--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -126,7 +126,7 @@ module Hanami
         #
         # @since 0.1.0
         def locals
-          Utils::Hash.deep_dup(@locals || @scope.locals)
+          (@locals || @scope.locals).dup
         end
 
         # It tries to invoke a method for the view or a local for the given key.

--- a/lib/hanami/view/rendering/options.rb
+++ b/lib/hanami/view/rendering/options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/utils/hash"
-
 module Hanami
   module View
     module Rendering
@@ -13,7 +11,7 @@ module Hanami
         # @since 1.1.1
         # @api private
         def self.build(options, locals, format)
-          Utils::Hash.deep_dup(options).tap do |opts|
+          options.dup.tap do |opts|
             opts[:format] = format
             opts[:locals] = locals
             opts[:locals].merge!(options.fetch(:locals) { ::Hash.new }).merge!(format: format)

--- a/spec/support/fixtures/fixtures.rb
+++ b/spec/support/fixtures/fixtures.rb
@@ -548,10 +548,18 @@ module DeepPartials
     root __dir__ + '/templates/deep_partials/templates'
   end
 
+  class BooksCollection
+    undef :initialize_dup
+  end
+
   module Views
     module Home
       class Index
         include DeepPartials::View
+
+        def books
+          BooksCollection.new
+        end
       end
     end
   end

--- a/spec/support/fixtures/templates/deep_partials/templates/home/index.html.erb
+++ b/spec/support/fixtures/templates/deep_partials/templates/home/index.html.erb
@@ -1,3 +1,3 @@
 View before, <%= name %>
-<%= render partial: 'shared/partial', locals: { name: 'Inner' } %>
+<%= render partial: 'shared/partial', locals: { name: 'Inner', books: books } %>
 View after, <%= name %>


### PR DESCRIPTION
With #140 we introduced deep duplication of locals to fix #139.

But objects that can't be duplicated (e.g. `ROM::Relation::Composite`, aka `ROM::Repository::RelationProxy`), will raise a `NoMethodError`.

Here's a typical scenario:

```ruby
class ContributorRepository < Hanami::Repository
  def listing
    contributors.order { commits_count.desc }
  end
end
```

```ruby
module Web::Controllers::Home
  class Index
    include Web::Action
    expose :contributors

    def call(*)
      @contributors = ContributorRepository.new.listing
    end
  end
end
```

That `contributors` exposure can't be duped, and it raises an error.
