### PR TITLE
Ensure to raise NoMethodError when a missing error with arity > 0 is used

### DIFF
--- a/lib/hanami/view/rendering.rb
+++ b/lib/hanami/view/rendering.rb
@@ -196,7 +196,7 @@ module Hanami
         #   view     = IndexView.new(template, {article: article})
         #
         #   view.article # => #<Article:0x007fb0bbd3b6e8>
-        def method_missing(m)
+        def method_missing(m, *)
           @scope.__send__ m
         end
       end

--- a/spec/support/fixtures/fixtures.rb
+++ b/spec/support/fixtures/fixtures.rb
@@ -13,6 +13,14 @@ class RenderView
   include Hanami::View
 end
 
+class RenderUnknownMethod
+  include Hanami::View
+
+  def render
+    foo "bar"
+  end
+end
+
 class RenderViewMethodOverride
   include Hanami::View
 

--- a/spec/unit/hanami/view_spec.rb
+++ b/spec/unit/hanami/view_spec.rb
@@ -112,6 +112,10 @@ RSpec.describe Hanami::View do
       expect(RenderView.render(format: :html, planet: 'Mars')).to include %(<h1>Hello, Mars!</h1>)
     end
 
+    it 'raises error if an unexisting method is referenced' do
+      expect { RenderUnknownMethod.render(format: :html) }.to raise_error(NoMethodError, /foo/)
+    end
+
     # See https://github.com/hanami/view/issues/76
     it 'renders a template with different encoding' do
       expect(EncodingView.render(format: :html)).to include %(Configuração)


### PR DESCRIPTION
While trying to reproduce https://github.com/hanami/view/issues/151 I discovered a problem.

If we reference a missing method with arity > 0, then `Hanami::View::Rendering#method_missing` crashes because the signature is: `method_missing(m)`. To override this Ruby method, we should accept any argument.

It ended up to raise an error like this:

```ruby
ArgumentError at 
wrong number of arguments (given 2, expected 1)
```

When we use an unknown method it should raise `NoMethodError` instead.
This PR addresses the problem.