### PR TITLE
Allow layout to be rendered directly for testing purposes

### DIFF
--- a/lib/hanami/layout.rb
+++ b/lib/hanami/layout.rb
@@ -2,6 +2,7 @@ require 'hanami/utils/class_attribute'
 require 'hanami/view/rendering/layout_registry'
 require 'hanami/view/rendering/layout_scope'
 require 'hanami/view/rendering/null_layout'
+require 'hanami/view/rendering/null_view'
 
 module Hanami
   # Layout
@@ -124,7 +125,9 @@ module Hanami
     #
     # @see Hanami::View::Rendering#render
     def initialize(scope, rendered)
-      @scope, @rendered = View::Rendering::LayoutScope.new(self, scope), rendered
+      scope = Hanami::View::Rendering::Scope.new(Hanami::View::Rendering::NullView, scope) if scope.is_a?(::Hash)
+      @scope = View::Rendering::LayoutScope.new(self, scope)
+      @rendered = rendered
     end
 
     # Render the layout

--- a/lib/hanami/layout.rb
+++ b/lib/hanami/layout.rb
@@ -117,7 +117,12 @@ module Hanami
 
     # Initialize a layout
     #
-    # @param scope [Hanami::View::Rendering::Scope] view rendering scope
+    # @param scope [Hanami::View::Rendering::Scope,::Hash] view rendering scope.
+    #   Optionally a scope can be expressed as a Ruby `::Hash`, but it MUST contain
+    #   the `:format` key, to specify which template to render.
+    # @option scope [Symbol] :format the format to render (e.g. `:html`, `:xml`, `:json`)
+    #   This is mandatory only if a `:Hash` is passed as `scope`.
+    #
     # @param rendered [String] the output of the view rendering process
     #
     # @api private

--- a/lib/hanami/layout.rb
+++ b/lib/hanami/layout.rb
@@ -130,9 +130,19 @@ module Hanami
     #
     # @see Hanami::View::Rendering#render
     def initialize(scope, rendered)
-      scope = Hanami::View::Rendering::Scope.new(Hanami::View::Rendering::NullView, scope) if scope.is_a?(::Hash)
-      @scope = View::Rendering::LayoutScope.new(self, scope)
-      @rendered = rendered
+      # NOTE: This complex data transformation is due to a combination of a bug and the intent of maintaing backward compat (SemVer).
+      # See https://github.com/hanami/view/pull/156
+      s, r = *case scope
+              when ::Hash
+                [Hanami::View::Rendering::Scope.new(Hanami::View::Rendering::NullView, scope), rendered]
+              when Hanami::View::Template
+                [Hanami::View::Rendering::Scope.new(Hanami::View::Rendering::NullView, rendered.merge(format: scope.format)), ""]
+              else
+                [scope, rendered]
+              end
+
+      @scope = View::Rendering::LayoutScope.new(self, s)
+      @rendered = r
     end
 
     # Render the layout

--- a/lib/hanami/view/rendering/null_view.rb
+++ b/lib/hanami/view/rendering/null_view.rb
@@ -1,0 +1,26 @@
+module Hanami
+  module View
+    module Rendering
+      # Null Object pattern for view
+      #
+      # It's used when a layout is rendered direcly for testing purposes
+      #
+      # @api private
+      # @since x.x.x
+      class NullView
+        # Render the layout template
+        #
+        # @return [String] an empty string
+        #
+        # @api private
+        # @since x.x.x
+        #
+        # @see Hanami::Layout#render
+        # @see Hanami::View::Rendering#render
+        def render
+          ""
+        end
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/fixtures.rb
+++ b/spec/support/fixtures/fixtures.rb
@@ -112,6 +112,10 @@ class ApplicationLayout
   end
 end
 
+class LocalsLayout
+  include Hanami::Layout
+end
+
 class ContactsLayout
   include Hanami::Layout
 end

--- a/spec/support/fixtures/templates/locals.html.haml
+++ b/spec/support/fixtures/templates/locals.html.haml
@@ -1,0 +1,6 @@
+!!!
+%html
+  %head
+    %title Locals
+  %body
+    = yield

--- a/spec/unit/hanami/layout_spec.rb
+++ b/spec/unit/hanami/layout_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe Hanami::Layout do
     end
   end
 
+  # Bug https://github.com/hanami/view/issues/153
+  it 'can be rendered directly' do
+    rendered = LocalsLayout.new({ format: :html }, "contents").render
+
+    expect(rendered).to include("Locals")
+    expect(rendered).to include("contents")
+  end
+
   it 'concrete methods are available in layout template' do
     rendered = Store::Views::Home::Index.render(format: :html)
     expect(rendered).to match %(script)

--- a/spec/unit/hanami/layout_spec.rb
+++ b/spec/unit/hanami/layout_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe Hanami::Layout do
     expect(rendered).to include("contents")
   end
 
+  # Bug https://github.com/hanami/view/issues/153
+  # See https://github.com/hanami/view/pull/156
+  it 'can be rendered directly (legacy signature)' do
+    template = Hanami::View::Template.new("spec/support/fixtures/templates/locals.html.haml")
+    layout = LocalsLayout.new(template, {})
+    rendered = layout.render
+
+    expect(rendered).to include("Locals")
+    expect(rendered).to include("<body>\n\n</body>")
+  end
+
   it 'concrete methods are available in layout template' do
     rendered = Store::Views::Home::Index.render(format: :html)
     expect(rendered).to match %(script)

--- a/spec/unit/hanami/view/rendering/null_view_spec.rb
+++ b/spec/unit/hanami/view/rendering/null_view_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Hanami::View::Rendering::NullView do
+  subject { described_class.new }
+
+  describe '#render' do
+    it 'returns empty string' do
+      expect(subject.render).to eq('')
+    end
+  end
+end


### PR DESCRIPTION
Until Hanami v1.2.0 we generate a wrong spec for layout unit tests.

```ruby
# spec/web/views/application_layout_spec.rb
require "spec_helper"

RSpec.describe Web::Views::ApplicationLayout, type: :view do
  let(:layout)   { Web::Views::ApplicationLayout.new(template, {}) }
  let(:rendered) { layout.render }
  let(:template) { Hanami::View::Template.new('apps/web/templates/application.html.haml') }

  it 'contains application name' do
    expect(rendered).to include('Web')
  end
end
```

If we look at the signature of `Hanami::Layout#initialize` we'll see it accept two arguments: `scope` and `rendered`.

The first must be a `Hanami::View::Rendering::Scope` instance. It's an internal object composed by `hanami-view`, that wraps the locals and the **format** to be rendered (e.g. `:html`).

The second argument is a string, and it's the result of the view rendering. E.g. a template is made of:

```erb
<p>Hello <%= name %>!</p>
```

Then the `rendered` value will be `<p>Hello Luca!</p>`.

---

Getting back to our generated code above, it **doesn't respect the signature** of `Hanami::Layout#initialize`. With ERB templates it **accidentally worked**, but for HAML, it didn't (see https://github.com/hanami/view/issues/153).

---

The purpose of this PR is to make `Hanami::Layout` ready to be unit tested properly with:

```ruby
rendered = ApplicationLayout.new({ format: :html }, "contents").render
```

On a subsequent PR, I'll fix the code generator for `hanami`.

---

Fixes https://github.com/hanami/view/issues/153