### PR TITLE
Make `Hanami::View::Rendering::LayoutScope` to inherit from `Hanami::Utils::BasicObject`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['CI']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils', '~> 1.3', require: false, git: 'https://github.com/hanami/utils.git', branch: 'enhancement/basic-object-constants-lookup'
+gem 'hanami-utils', '~> 1.3', require: false, git: 'https://github.com/hanami/utils.git', branch: 'master'
 gem 'haml',         '~> 5.0', require: false
 gem 'slim',         '~> 4.0', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['CI']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils', '~> 1.3', require: false, git: 'https://github.com/hanami/utils.git', branch: 'master'
+gem 'hanami-utils', '~> 1.3', require: false, git: 'https://github.com/hanami/utils.git', branch: 'enhancement/basic-object-constants-lookup'
 gem 'haml',         '~> 5.0', require: false
 gem 'slim',         '~> 4.0', require: false
 

--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -33,15 +33,6 @@ module Hanami
           @locals = nil
         end
 
-        # Returns the classname as string
-        #
-        # @return classname
-        #
-        # @since 0.3.0
-        def class
-          (class << self; self end).superclass
-        end
-
         # Returns an inspect String
         #
         # @return [String] inspect String (contains classname, objectid in hex, available ivars)

--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -33,18 +33,6 @@ module Hanami
           @locals = nil
         end
 
-        # Returns an inspect String
-        #
-        # @return [String] inspect String (contains classname, objectid in hex, available ivars)
-        #
-        # @since 0.3.0
-        def inspect
-          base = "#<#{ self.class }:#{'%x' % (self.object_id << 1)}"
-          base << " @layout=\"#{@layout.inspect}\"" if @layout
-          base << " @scope=\"#{@scope.inspect}\"" if @scope
-          base << ">"
-        end
-
         # Render a partial or a template within a layout template.
         #
         # @param options [Hash]
@@ -245,6 +233,19 @@ module Hanami
         end
 
         private
+
+        # Returns an inspect String
+        #
+        # @return [String] inspect String (contains classname, objectid in hex, available ivars)
+        #
+        # @since x.x.x
+        # @api private
+        def __inspect
+          result = ""
+          result += %( @layout="#{@layout.inspect}") if @layout
+          result += %( @scope="#{@scope.inspect}") if @scope
+          result
+        end
 
         # @api private
         def _options(options)

--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -1,6 +1,7 @@
 require 'hanami/view/rendering/null_local'
 require 'hanami/view/rendering/options'
 require 'hanami/utils/escape'
+require 'hanami/utils/basic_object'
 
 module Hanami
   module View
@@ -16,7 +17,7 @@ module Hanami
       # Scope for layout rendering
       #
       # @since 0.1.0
-      class LayoutScope < BasicObject
+      class LayoutScope < Utils::BasicObject
         # Initialize the scope
         #
         # @param layout [Hanami::Layout] the layout to render

--- a/spec/unit/hanami/view/rendering/layout_scope_spec.rb
+++ b/spec/unit/hanami/view/rendering/layout_scope_spec.rb
@@ -79,6 +79,28 @@ RSpec.describe Hanami::View::Rendering::LayoutScope do
     end
   end
 
+  describe '#is_a?' do
+    it 'returns true if checked against ::BasicObject' do
+      expect(@scope.is_a?(BasicObject)).to be(true)
+    end
+
+    it 'returns true if checked against Hanami::Utils::BasicObject' do
+      expect(@scope.is_a?(Hanami::Utils::BasicObject)).to be(true)
+    end
+
+    it "returns true if checked against #{described_class}" do
+      expect(@scope.is_a?(described_class)).to be(true)
+    end
+
+    it 'returns false if checked against ::Object' do
+      expect(@scope.is_a?(Object)).to be(false)
+    end
+
+    it 'returns false if checked against ::Module' do
+      expect(@scope.is_a?(Module)).to be(false)
+    end
+  end
+
   describe '#render' do
     describe 'render with no known render type' do
       it 'raises UnknownRenderTypeError' do


### PR DESCRIPTION
## What

Make `Hanami::View::Rendering::LayoutScope` to inherit from `Hanami::Utils::BasicObject` instead from Ruby's `BasicObject`.

This ensures a better interoperability with latest `tilt` changes. See https://github.com/rtomayko/tilt/issues/347

## Technical details

  * `Hanami::View::Rendering::LayoutScope#is_a?` is no longer implicitly dispatched to the internal `@scope` as per effect of `#method_missing`. Because `Hanami::Utils::BasicObject` implements `#is_a?`, `#method_missing` is no longer called. It's important for `Hanami::View::Rendering::LayoutScope` to take control on `#is_a?` because it led to unexpected behaviors like `is_a?(Module)` to return `true`, because the current `@scope` was a `Module`. Of course `Hanami::View::Rendering::LayoutScope` isn't a `Module`, but a basic object, and `#is_a?` must reflect it.

  * `Hanami::View::Rendering::LayoutScope#class` was removed because it's already implemented by the new superclass: `Hanami::Utils::BasicObject`.

  * The behavior of `#inspect` is extracted into the private method `#__inspect`. This is a `Utils::BasicObject` [hook](https://github.com/hanami/utils/blob/master/lib/hanami/utils/basic_object.rb#L27) to allow its subclasses to define their own inspect logic. `Hanami::View::Rendering::LayoutScope` will still continue to respond to `#inspect` and to return the same inspecting string. The implementation is now split between the new superclass and the layout scope itself.

  * ~~`Gemfile` temporary points to `hanami-utils` branch that contains another `Utils::BasicObject` fix that makes `hanami-view` build to pass with `tilt` `2.0.10`. See https://github.com/hanami/utils/pull/343~~
