### PR TITLE
Fix LayoutScope#render's documentation

### DIFF
--- a/lib/hanami/view/rendering/layout_scope.rb
+++ b/lib/hanami/view/rendering/layout_scope.rb
@@ -74,7 +74,7 @@ module Hanami
         #   #   templates/application.html.erb
         #   #
         #   # Use like this:
-        #   <%= render partial: 'shared/sidebar', { user: current_user } %>
+        #   <%= render partial: 'shared/sidebar', locals: { user: current_user } %>
         #
         #   #
         #   # `user` will be available in the scope of the sidebar rendering


### PR DESCRIPTION
The `:locals` example didn't have valid syntax, probably due to a typo.