### PR TITLE
Hanami::View::Rendering::TemplateName: Fix frozen string literal error

### DIFF
--- a/lib/hanami/view/rendering/template_name.rb
+++ b/lib/hanami/view/rendering/template_name.rb
@@ -42,7 +42,7 @@ module Hanami
         # @since 0.2.0
         # @api private
         def replace!(token)
-          @name.gsub!(%r{\A#{ token }#{ NAMESPACE_SEPARATOR }}, '')
+          @name = @name.gsub(%r{\A#{ token }#{ NAMESPACE_SEPARATOR }}, '')
         end
       end
     end


### PR DESCRIPTION
## Problems
It's impossible to run `hanami server` when using ruby 2.7.0 (the reasons are below)

### Causes
- https://github.com/hanami/view/blob/9af8499ae1e7ce81c7eb85167222d9b3bfff2ec7/lib/hanami/view/rendering/template_name.rb#L45
  - It's using bang method `gsub!` here. It works as long as `@name` as String is not frozen.
- https://github.com/hanami/view/blob/9af8499ae1e7ce81c7eb85167222d9b3bfff2ec7/lib/hanami/view/dsl.rb#L208
  - It passes `Module#name` method as arugument. And it will be assigned to `@name` in `Rendering::TemplateName#initialize`.
- The behavioir `Module#name` has been changed since Ruby 2.7.0. *[ref](https://rubyreferences.github.io/rubychanges/2.7.html#core-methods-returning-frozen-strings)
  - the previous behavior: `(Foo = Module.new).name.frozen? #=> false`
  - the current behavior: `(Foo = Module.new).name.frozen? #=> true`

## Execution Environment
- ruby 2.7.0
- hanami 1.3.3
- hanami-view 1.3.2

## Steps to reproduce the problem
1. Use ruby `2.7.0` 
2. `hanami new bookshelf` & `bundle install`
3. `bundle exec hanami server` -> then, the issued problem occurs
 
## others
<details>
<summary>error log</summary>

```log
Boot Error
Something went wrong while loading /Users/mitsubosh/Practice/043_hanami/bookshelf/config.ru

FrozenError: can't modify frozen String: "Web::Views::ApplicationLayout"
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/template_name.rb:45:in `gsub!'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/template_name.rb:45:in `replace!'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/template_name.rb:30:in `block in compile!'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/template_name.rb:38:in `block in tokens'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/template_name.rb:37:in `each'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/template_name.rb:37:in `tokens'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/template_name.rb:30:in `compile!'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/template_name.rb:17:in `initialize'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/dsl.rb:208:in `new'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/dsl.rb:208:in `template'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/layout.rb:82:in `template'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/templates_finder.rb:103:in `template_name'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/templates_finder.rb:86:in `_find'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/templates_finder.rb:72:in `find'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/layout_registry.rb:58:in `templates'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/layout_registry.rb:49:in `prepare!'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/rendering/layout_registry.rb:24:in `initialize'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/layout.rb:62:in `new'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/layout.rb:62:in `registry'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/layout.rb:114:in `load_registry!'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/layout.rb:105:in `load!'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/configuration.rb:422:in `block in load!'
/Users/mitsubosh/.rbenv/versions/2.7.0/lib/ruby/2.7.0/set.rb:328:in `each_key'
/Users/mitsubosh/.rbenv/versions/2.7.0/lib/ruby/2.7.0/set.rb:328:in `each'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view/configuration.rb:422:in `load!'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-view-1.3.2/lib/hanami/view.rb:264:in `load!'
(eval):1:in `block (2 levels) in <module:Components>'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/components.rb:474:in `module_eval'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/components.rb:474:in `block (2 levels) in <module:Components>'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/component.rb:40:in `call'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/components.rb:362:in `block (3 levels) in <module:Components>'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/components.rb:361:in `each'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/components.rb:361:in `block (2 levels) in <module:Components>'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/component.rb:40:in `call'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/components.rb:278:in `block (3 levels) in <module:Components>'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/configuration.rb:144:in `block in apps'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/configuration.rb:143:in `each_pair'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/configuration.rb:143:in `apps'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/components.rb:277:in `block (2 levels) in <module:Components>'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/component.rb:44:in `call'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components.rb:108:in `block (2 levels) in resolve'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.5/lib/concurrent/map.rb:193:in `block in fetch_or_store'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.5/lib/concurrent/map.rb:172:in `fetch'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.5/lib/concurrent/map.rb:192:in `fetch_or_store'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components.rb:106:in `block in resolve'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components.rb:105:in `each'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components.rb:105:in `resolve'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/component.rb:144:in `resolve_requirements'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components/component.rb:36:in `call'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components.rb:108:in `block (2 levels) in resolve'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.5/lib/concurrent/map.rb:193:in `block in fetch_or_store'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.5/lib/concurrent/map.rb:172:in `fetch'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/concurrent-ruby-1.1.5/lib/concurrent/map.rb:192:in `fetch_or_store'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components.rb:106:in `block in resolve'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components.rb:105:in `each'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/components.rb:105:in `resolve'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami.rb:126:in `boot'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami.rb:151:in `app'
/Users/mitsubosh/Practice/043_hanami/bookshelf/config.ru:3:in `block in inner_app'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/rack-2.0.8/lib/rack/builder.rb:55:in `instance_eval'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/rack-2.0.8/lib/rack/builder.rb:55:in `initialize'
/Users/mitsubosh/Practice/043_hanami/bookshelf/config.ru:1:in `new'
/Users/mitsubosh/Practice/043_hanami/bookshelf/config.ru:1:in `inner_app'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:113:in `eval'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:113:in `inner_app'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:103:in `assemble_app'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:86:in `proceed_as_child'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:31:in `call!'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/shotgun-0.9.2/lib/shotgun/loader.rb:18:in `call'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/hanami-1.3.3/lib/hanami/assets/static.rb:49:in `call'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/rack-2.0.8/lib/rack/lint.rb:49:in `_call'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/rack-2.0.8/lib/rack/lint.rb:37:in `call'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/rack-2.0.8/lib/rack/show_exceptions.rb:23:in `call'
/Users/mitsubosh/Practice/043_hanami/bookshelf/vendor/bundle/ruby/2.7.0/gems/rack-2.0.8/lib/rack/handler/webrick.rb:86:in `service'
/Users/mitsubosh/.rbenv/versions/2.7.0/lib/ruby/2.7.0/webrick/httpserver.rb:140:in `service'
/Users/mitsubosh/.rbenv/versions/2.7.0/lib/ruby/2.7.0/webrick/httpserver.rb:96:in `run'
/Users/mitsubosh/.rbenv/versions/2.7.0/lib/ruby/2.7.0/webrick/server.rb:307:in `block in start_thread'
```

</details>