### PR TITLE
Automatically apply view config for copying into application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem "erubi"
   gem "hamlit"
   gem "hamlit-block"
-  gem "hanami", github: "hanami/hanami", branch: "unstable"
+  gem "hanami", github: "hanami/hanami", branch: "enhancement/unstable/view-settings"
   gem "hanami-devtools", github: "hanami/devtools"
   gem "rack", ">= 2.0.6"
   gem "slim", "~> 4.0"

--- a/lib/hanami/view.rb
+++ b/lib/hanami/view.rb
@@ -71,6 +71,21 @@ module Hanami
     # @!scope class
     setting :template
 
+    # @overload config.template_inference_base=(base_path)
+    #   Set the base path to strip away when when inferring a view's template
+    #   names from its class name.
+    #
+    #   **This setting only applies for views within an Hanami application.**
+    #
+    #   For example, given a view `Main::Views::Articles::Index`, in the `Main`
+    #   slice, and a template_inference_base of "views", the inferred template
+    #   name will be "articles/index".
+    #
+    #   @param base_path [String, nil] base templates path
+    #   @api public
+    # @!scope class
+    setting :template_inference_base
+
     # @overload config.layout=(name)
     #   Set the name of the layout to render templates within. Layouts will be
     #   looked up within the configured `layouts_dir`, within the configured


### PR DESCRIPTION
This follows the pattern we established for Hanami actions in https://github.com/hanami/controller/pull/320 and makes it so that an "application view" has all of its configuration applied from a matching `Hanami.application.config.views` application-level config object.

Along with this, this includes a few adjustments to make it so that the `Hanami::View.config` includes _all_ the necessary settings that are required for application views (instead of some settings having to reside exclusively within the application config). This includes:

- A new handling of the `paths` setting for application views: if the application’s own “paths” setting is a relative path, then it will now be appended onto the application provider’s root path (e.g. the slice or application root paths). This makes it possible to configure a standard “sub-path” at the application level that will then work for views in any given slice.
- A new `template_inference_base` setting, which will currently be used only when auto-inferring template names for application views. Later on, I might consider supporting template name inference _in general_ (i.e. even for views used outside  Hanami applications, but this this is outside the scope of this PR).