### PR TITLE
Create ApplicationContext and (initial) context helpers for use within full Hanami apps

### DIFF
--- a/lib/hanami/view/application_context.rb
+++ b/lib/hanami/view/application_context.rb
@@ -3,8 +3,8 @@
 module Hanami
   class View
     module ApplicationContext
-      def initialize(**options)
-        @inflector = options.fetch(:inflector) { Hanami.application.inflector }
+      def initialize(inflector: Hanami.application.inflector, **options)
+        @inflector = inflector
         super
       end
 

--- a/lib/hanami/view/application_context.rb
+++ b/lib/hanami/view/application_context.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative "context"
+
+module Hanami
+  module View
+    class ApplicationContext < Context
+      attr_reader :inflector
+
+      def initialize(**options)
+        @inflector = options.fetch(:inflector) { Hanami.application.inflector }
+        super(**options)
+      end
+
+      def request
+        _options.fetch(:request)
+      end
+
+      def session
+        request.session
+      end
+
+      def flash
+        response.flash
+      end
+
+      private
+
+      # TODO: put `flash` on Request and stop passing response to view context
+      def response
+        _options.fetch(:response)
+      end
+    end
+  end
+end

--- a/lib/hanami/view/application_context.rb
+++ b/lib/hanami/view/application_context.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require_relative "context"
-
 module Hanami
-  module View
-    class ApplicationContext < Context
-      attr_reader :inflector
-
+  class View
+    module ApplicationContext
       def initialize(**options)
         @inflector = options.fetch(:inflector) { Hanami.application.inflector }
-        super(**options)
+        super
+      end
+
+      def inflector
+        @inflector
       end
 
       def request
@@ -26,7 +26,7 @@ module Hanami
 
       private
 
-      # TODO: put `flash` on Request and stop passing response to view context
+      # TODO: create `Request#flash` so we no longer need the `response`
       def response
         _options.fetch(:response)
       end

--- a/lib/hanami/view/context.rb
+++ b/lib/hanami/view/context.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/equalizer"
+require_relative "application_context"
 require_relative "decorated_attributes"
 
 module Hanami
@@ -17,6 +18,22 @@ module Hanami
       include DecoratedAttributes
 
       attr_reader :_render_env, :_options
+
+      def self.inherited(subclass)
+        super
+
+        # When inheriting within an Hanami app, add application context behavior
+        if application_provider(subclass)
+          subclass.include ApplicationContext
+        end
+      end
+
+      def self.application_provider(subclass)
+        if Hanami.respond_to?(:application?) && Hanami.application?
+          Hanami.application.component_provider(subclass)
+        end
+      end
+      private_class_method :application_provider
 
       # Returns a new instance of Context
       #

--- a/lib/hanami/view/context_helpers/content_for.rb
+++ b/lib/hanami/view/context_helpers/content_for.rb
@@ -1,0 +1,26 @@
+module Hanami
+  module View
+    module ContextHelpers
+      module ContentFor
+        def initialize(**options)
+          super(**options.merge(content: {}))
+        end
+
+        def content_for(key, value = nil, &block)
+          content = _options[:content]
+          output = nil
+
+          if block
+            content[key] = yield
+          elsif value
+            content[key] = value
+          else
+            output = content[key]
+          end
+
+          output
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/view/context_helpers/content_helpers.rb
+++ b/lib/hanami/view/context_helpers/content_helpers.rb
@@ -1,9 +1,9 @@
 module Hanami
-  module View
+  class View
     module ContextHelpers
-      module ContentFor
-        def initialize(**options)
-          super(**options.merge(content: {}))
+      module ContentHelpers
+        def initialize(content: {}, **options)
+          super
         end
 
         def content_for(key, value = nil, &block)

--- a/spec/integration/context/application_context/activation_spec.rb
+++ b/spec/integration/context/application_context/activation_spec.rb
@@ -1,0 +1,39 @@
+require "hanami"
+require "hanami/view/context"
+
+RSpec.describe "Application context / Activation", :application_integration do
+  context "Inside Hanami app" do
+    before do
+      module TestApp
+        class Application < Hanami::Application
+        end
+      end
+
+      Hanami.init
+    end
+
+    subject(:context_class) {
+      module TestApp
+        module View
+          class Context < Hanami::View::Context
+          end
+        end
+      end
+      TestApp::View::Context
+    }
+
+    it "is an ApplicationContext" do
+      expect(context_class.ancestors).to include Hanami::View::ApplicationContext
+    end
+  end
+
+  context "Outside Hanami app" do
+    subject(:context_class) {
+      Class.new(Hanami::View::Context)
+    }
+
+    it "is not an ApplicationContext" do
+      expect(context_class.ancestors).not_to include Hanami::View::ApplicationContext
+    end
+  end
+end

--- a/spec/integration/context/application_context/inflector_spec.rb
+++ b/spec/integration/context/application_context/inflector_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe "Application context / Inflector", :application_integration do
       it "is the injected inflector" do
         expect(context.inflector).to be inflector
       end
+
+      context "rebuilt context" do
+        subject(:new_context) { context.with }
+
+        it "retains the injected inflector" do
+          expect(new_context.inflector).to be inflector
+        end
+      end
     end
   end
 end

--- a/spec/integration/context/application_context/inflector_spec.rb
+++ b/spec/integration/context/application_context/inflector_spec.rb
@@ -1,0 +1,45 @@
+require "hanami"
+require "hanami/view/context"
+
+RSpec.describe "Application context / Inflector", :application_integration do
+  before do
+    module TestApp
+      class Application < Hanami::Application
+      end
+    end
+
+    Hanami.init
+  end
+
+  let(:context_class) {
+    module TestApp
+      module View
+        class Context < Hanami::View::Context
+        end
+      end
+    end
+    TestApp::View::Context
+  }
+
+  subject(:context) {
+    context_class.new
+  }
+
+  describe "#inflector" do
+    it "is the application inflector by default" do
+      expect(context.inflector).to be TestApp::Application.inflector
+    end
+
+    context "injected inflector" do
+      subject(:context) {
+        context_class.new(inflector: inflector)
+      }
+
+      let(:inflector) { double(:inflector) }
+
+      it "is the injected inflector" do
+        expect(context.inflector).to be inflector
+      end
+    end
+  end
+end

--- a/spec/integration/context/application_context/request_spec.rb
+++ b/spec/integration/context/application_context/request_spec.rb
@@ -1,0 +1,63 @@
+require "hanami"
+require "hanami/view/context"
+
+RSpec.describe "Application context / Request", :application_integration do
+  before do
+    module TestApp
+      class Application < Hanami::Application
+      end
+    end
+
+    Hanami.init
+  end
+
+  let(:context_class) {
+    module TestApp
+      module View
+        class Context < Hanami::View::Context
+        end
+      end
+    end
+    TestApp::View::Context
+  }
+
+  subject(:context) {
+    context_class.new(
+      request: request,
+      response: response,
+    )
+  }
+
+  let(:request) { double(:request) }
+  let(:response) { double(:response) }
+
+  describe "#request" do
+    it "is the provided request" do
+      expect(context.request).to be request
+    end
+  end
+
+  describe "#sesion" do
+    let(:session) { double(:session) }
+
+    before do
+      allow(request).to receive(:session) { session }
+    end
+
+    it "is the request's session" do
+      expect(context.session).to be session
+    end
+  end
+
+  describe "#flash" do
+    let(:flash) { double(:flash) }
+
+    before do
+      allow(response).to receive(:flash) { flash }
+    end
+
+    it "is the response's flash" do
+      expect(context.flash).to be flash
+    end
+  end
+end

--- a/spec/unit/context_helpers/content_helpers_spec.rb
+++ b/spec/unit/context_helpers/content_helpers_spec.rb
@@ -1,0 +1,46 @@
+require "hanami/view/context"
+require "hanami/view/context_helpers/content_helpers"
+
+RSpec.describe Hanami::View::Context, "ContentHelpers" do
+  let(:context) {
+    Class.new(described_class) do
+      include Hanami::View::ContextHelpers::ContentHelpers
+    end.new
+  }
+
+  describe "#content_for" do
+    context "no content set" do
+      it "returns nil" do
+        expect(context.content_for(:title)).to be nil
+      end
+    end
+
+    context "content set" do
+      before do
+        context.content_for :title, "Hello World"
+      end
+
+      it "returns the content" do
+        expect(context.content_for(:title)).to eq "Hello World"
+      end
+
+      context "rebuilt context" do
+        subject(:new_context) { context.with }
+
+        it "retains the content" do
+          expect(new_context.content_for(:title)).to eq "Hello World"
+        end
+      end
+    end
+
+    context "content set with a block" do
+      before do
+        context.content_for(:title) { "Hello Block" }
+      end
+
+      it "saves the content returned from the block" do
+        expect(context.content_for(:title)).to eq "Hello Block"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the beginning of Seamless Application Integration™️ to `Hanami::View::Context`.

Like we already do for `Hanami::View` and `Hanami::Action`, now when you inherit from `Hanami::View::Context` from within an Hanami application module, you'll get extra application-specific behaviours provided automatically.

To start with, this is reader methods for the `#request`, `#session`, and `#flash` (which will work with the `request` and `response` objects already provided as part of the `#view_context_options` in `Hanami::Action`'s view rendering integration.

No fancy metaprogramming required for this one, just a standard module with some instance methods.

n.b. this is certainly _not_ the final endpoint of the application context behavior, but it's a helpful starting point and required for application authors to fully access the features provided via the action/view rendering integration.

Along with this, this PR also provides an experimental new `Hanami::View::ContextHelpers::ContentHelpers` module, which can be explicitly included into an application's context class to opt into some extra behavior on the application's view context. I imagine this pattern could be extended to provide an entire "standard library" of opt-in view context behavior. If this proves a useful approach, I'd imagine we could add some class-level niceties to make it easier to opt in without having to provide the fully qualified module names, but in the meantime, this is a simpler way to test the waters.
