### PR TITLE
Provide context object from template to layout

### DIFF
--- a/lib/hanami/view/standalone_view.rb
+++ b/lib/hanami/view/standalone_view.rb
@@ -265,7 +265,9 @@ module Hanami
           output = env.template(config.template, template_env.scope(config.scope, locals))
 
           if layout?
-            layout_env = self.class.layout_env(format: format, context: context)
+            # Use the template_env's context so the layout can have access to any context
+            # state changed within the template (to support `content_for`-style behaviour)
+            layout_env = self.class.layout_env(format: format, context: template_env.context)
             output = env.template(
               self.class.layout_path,
               layout_env.scope(config.scope, layout_locals(locals))

--- a/spec/fixtures/integration/view/rendering/context_reuse/layouts/application.html.slim
+++ b/spec/fixtures/integration/view/rendering/context_reuse/layouts/application.html.slim
@@ -1,0 +1,1 @@
+title = page_title

--- a/spec/fixtures/integration/view/rendering/context_reuse/template.html.slim
+++ b/spec/fixtures/integration/view/rendering/context_reuse/template.html.slim
@@ -1,0 +1,1 @@
+- page_title "Title from template"

--- a/spec/integration/view/rendering/context_reuse_spec.rb
+++ b/spec/integration/view/rendering/context_reuse_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "hanami/view"
+require "hanami/view/context"
+
+RSpec.describe "View / Rendering / Context reuse" do
+  specify "Context state set in template is available when rendering layout" do
+    view = Class.new(Hanami::View) do
+      config.paths = SPEC_ROOT.join("fixtures/integration/view/rendering/context_reuse")
+      config.template = "template"
+      config.layout = "application"
+    end.new
+
+    context = Class.new(Hanami::View::Context) do
+      def page_title(title = (no_args = true))
+        if no_args
+          _options[:page_title] || "Default title"
+        else
+          _options[:page_title] = title
+        end
+      end
+    end.new
+
+    output = view.(context: context).to_s
+
+    expect(output).to eq "<title>Title from template</title>"
+  end
+end


### PR DESCRIPTION
This makes it possible for the layout to access any context state changed from within the template, which is necessary to enable `content_for`-style behaviour, or e.g. for context helpers that allow the templates to set a page title, which is then output from the layout.