### PR TITLE
Configure application views with application inflector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ group :tools do
 end
 
 group :test do
+  gem "saharspec"
+
   gem "dry-inflector"
   gem "erbse", "~> 0.1.4"
   gem "erubi"

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :test do
   gem "hamlit"
   gem "hamlit-block"
   gem "hanami", github: "hanami/hanami", branch: "unstable"
+  gem "hanami-controller", github: "hanami/controller", branch: "unstable"
   gem "hanami-devtools", github: "hanami/devtools"
   gem "rack", ">= 2.0.6"
   gem "slim", "~> 4.0"

--- a/lib/hanami/view/application_configuration.rb
+++ b/lib/hanami/view/application_configuration.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative "../view"
+
+module Hanami
+  class View
+    class ApplicationConfiguration
+      def initialize
+        @base_config = View.config.dup
+
+        configure_defaults
+      end
+
+      # Returns the list of available settings
+      #
+      # @return [Set]
+      #
+      # @since 2.0.0
+      # @api private
+      def settings
+        View.settings - NON_FORWARDABLE_METHODS
+      end
+
+      private
+
+      attr_reader :base_config
+
+      def configure_defaults
+        self.paths = ["web/templates"]
+        self.template_inference_base = "views"
+        self.layout = "application"
+      end
+
+      # An inflector for views is not configurable via `config.views.inflector` on an
+      # `Hanami::Application`. The application-wide inflector is already configurable
+      # there as `config.inflector` and will be used as the default inflector for views.
+      #
+      # A custom inflector may still be provided in an `Hanami::View` subclass, via
+      # `config.inflector=`.
+      NON_FORWARDABLE_METHODS = [:inflector, :inflector=].freeze
+      private_constant :NON_FORWARDABLE_METHODS
+
+      def method_missing(name, *args, &block)
+        return super if NON_FORWARDABLE_METHODS.include?(name)
+
+        if base_config.respond_to?(name)
+          base_config.public_send(name, *args, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(name, _include_all = false)
+        return false if NON_FORWARDABLE_METHODS.include?(name)
+
+        base_config.respond_to?(name) || super
+      end
+    end
+  end
+end

--- a/lib/hanami/view/application_view.rb
+++ b/lib/hanami/view/application_view.rb
@@ -17,10 +17,13 @@ module Hanami
 
       def included(view_class)
         view_class.settings.each do |setting|
-          application_value = application.config.views.public_send(:"#{setting}")
-          view_class.config.public_send :"#{setting}=", application_value
+          if application.config.views.respond_to?(:"#{setting}")
+            application_value = application.config.views.public_send(:"#{setting}")
+            view_class.config.public_send :"#{setting}=", application_value
+          end
         end
 
+        view_class.config.inflector = provider.inflector
         view_class.config.paths = prepare_paths(provider, view_class.config.paths)
 
         view_class.extend inherited_hook

--- a/spec/integration/application_view/inflector_spec.rb
+++ b/spec/integration/application_view/inflector_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "hanami/view"
+
+RSpec.describe "Application view / Inflector", :application_integration do
+  before do
+    module TestApp
+      class Application < Hanami::Application
+      end
+    end
+
+    TestApp::Application.instance_eval(&application_class_config)
+
+    module Main
+    end
+
+    Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+    Hanami.init
+  end
+
+  let(:application_class_config) { proc {} }
+
+  subject(:view_class) {
+    module Main
+      class View < Hanami::View
+      end
+    end
+
+    Main::View
+  }
+
+  context "no application inflector configured" do
+    it "configures the view with the default application inflector" do
+      expect(view_class.config.inflector).to be TestApp::Application.config.inflector
+    end
+  end
+
+  context "custom inflections configured" do
+    let(:application_class_config) {
+      proc do
+        config.inflector do |inflections|
+          inflections.acronym "NBA"
+        end
+      end
+    }
+
+    it "configures the view with the customized application inflector" do
+      expect(view_class.config.inflector).to be TestApp::Application.config.inflector
+      expect(view_class.config.inflector.camelize("nba_jam")).to eq "NBAJam"
+    end
+  end
+
+  context "custom inflector configured on view class" do
+    let(:custom_inflector) { Object.new }
+
+    before do
+      view_class.config.inflector = custom_inflector
+    end
+
+    it "overrides the default application inflector" do
+      expect(view_class.config.inflector).to be custom_inflector
+    end
+  end
+end

--- a/spec/integration/application_view_spec.rb
+++ b/spec/integration/application_view_spec.rb
@@ -39,8 +39,12 @@ RSpec.describe "Application views" do
         end
 
         Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+
+        Hanami.application.tap(&application_pre_init_hook)
         Hanami.init
       end
+
+      let(:application_pre_init_hook) { proc { } }
 
       let(:base_view_class) {
         module Main
@@ -63,9 +67,11 @@ RSpec.describe "Application views" do
 
           describe "path" do
             context "relative path provided in application config" do
-              before do
-                Hanami.application.config.views.paths = ["templates"]
-              end
+              let(:application_pre_init_hook) {
+                proc do |application|
+                  application.config.views.paths = ["templates"]
+                end
+              }
 
               it "configures the path as the relative path appended onto the slice's root path" do
                 expect(config.paths.map { |path| path.dir.to_s }).to eq ["/path/to/app/slices/main/templates"]
@@ -73,9 +79,11 @@ RSpec.describe "Application views" do
             end
 
             context "absolute path provided in application config" do
-              before do
-                Hanami.application.config.views.paths = ["/absolute/path"]
-              end
+              let(:application_pre_init_hook) {
+                proc do |application|
+                  application.config.views.paths = ["/absolute/path"]
+                end
+              }
 
               it "leaves the absolute path in place" do
                 expect(config.paths.map { |path| path.dir.to_s }).to eq ["/absolute/path"]
@@ -130,8 +138,11 @@ RSpec.describe "Application views" do
 
     context "Base view defined directly inside application" do
       before do
+        Hanami.application.tap(&application_pre_init_hook)
         Hanami.init
       end
+
+      let(:application_pre_init_hook) { proc { } }
 
       let(:base_view_class) {
         module TestApp
@@ -152,11 +163,13 @@ RSpec.describe "Application views" do
         describe "config" do
           subject(:config) { view_class.config }
 
-          describe "path" do
+          describe "paths" do
             context "relative path provided in application config" do
-              before do
-                Hanami.application.config.views.paths = ["templates"]
-              end
+              let(:application_pre_init_hook) {
+                proc do |application|
+                  application.config.views.paths = ["templates"]
+                end
+              }
 
               it "configures the path as the relative path appended onto the slice's root path" do
                 expect(config.paths.map { |path| path.dir.to_s }).to eq ["/path/to/app/templates"]
@@ -164,9 +177,11 @@ RSpec.describe "Application views" do
             end
 
             context "absolute path provided in application config" do
-              before do
-                Hanami.application.config.views.paths = ["/absolute/path"]
-              end
+              let(:application_pre_init_hook) {
+                proc do |application|
+                  application.config.views.paths = ["/absolute/path"]
+                end
+              }
 
               it "leaves the absolute path in place" do
                 expect(config.paths.map { |path| path.dir.to_s }).to eq ["/absolute/path"]

--- a/spec/unit/application_configuration_spec.rb
+++ b/spec/unit/application_configuration_spec.rb
@@ -1,0 +1,54 @@
+require "hanami/view/application_configuration"
+require "saharspec/matchers/dont"
+
+RSpec.describe Hanami::View::ApplicationConfiguration do
+  subject(:configuration) { described_class.new }
+
+  it "includes base view configuration" do
+    expect(configuration).to respond_to(:paths)
+    expect(configuration).to respond_to(:paths=)
+  end
+
+  it "is does not include the inflector setting" do
+    expect(configuration).not_to respond_to(:inflector)
+    expect(configuration).not_to respond_to(:inflector=)
+  end
+
+  it "preserves default values from the base view configuration" do
+    expect(configuration.layouts_dir).to eq Hanami::View.config.layouts_dir
+  end
+
+  it "allows settings to be configured independently of the base view configuration" do
+    expect { configuration.layouts_dir = "custom_layouts" }
+      .to change { configuration.layouts_dir }.to("custom_layouts")
+      .and dont.change { Hanami::View.config.layouts_dir }
+  end
+
+  describe "specialised default values" do
+    describe "paths" do
+      it 'is ["web/templates"]' do
+        expect(configuration.paths).to match [
+          an_object_satisfying { |path| path.dir.to_s == "web/templates" }
+        ]
+      end
+    end
+
+    describe "template_inference_base" do
+      it 'is "views"' do
+        expect(configuration.template_inference_base).to eq "views"
+      end
+    end
+
+    describe "layout" do
+      it 'is "application"' do
+        expect(configuration.layout).to eq "application"
+      end
+    end
+  end
+
+  describe "#settings" do
+    it "includes all view settings apart from inflector" do
+      expect(configuration.settings).to eq Hanami::View.settings - [:inflector]
+    end
+  end
+end


### PR DESCRIPTION
Configure all views inside an Hanami application with the application's own inflector. This provides consistent inflections inside the view layer.

To do this:

1. Create an `Hanami::View::ApplicationConfiguration`, to provide the application-level `Application.config.views` configuration object, just like we already do for `Application.config.actions`
2. Hide the standard view `inflector` setting so that a separate inflector cannot be configured for views
3. Then pass the application-level inflector instead when setting up any `ApplicationView`

This PR relies upon and will be merged with https://github.com/hanami/hanami/pull/1081.