### PR TITLE
Configure template on all application views

### DIFF
--- a/lib/hanami/view/application_view.rb
+++ b/lib/hanami/view/application_view.rb
@@ -25,6 +25,7 @@ module Hanami
 
         view_class.config.inflector = provider.inflector
         view_class.config.paths = prepare_paths(provider, view_class.config.paths)
+        view_class.config.template = template_name(view_class)
 
         view_class.extend inherited_hook
       end

--- a/spec/integration/application_view/template_spec.rb
+++ b/spec/integration/application_view/template_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "hanami/view"
+
+RSpec.describe "Application view / Template", :application_integration do
+  subject(:template) { view_class.config.template }
+
+  before do
+    module TestApp
+      class Application < Hanami::Application
+      end
+    end
+
+    module Main
+    end
+
+    Hanami.application.instance_eval(&application_hook) if respond_to?(:application_hook)
+
+    Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+
+    Hanami.init
+  end
+
+  context "Direct Hanami::View subclass" do
+    let(:view_class) {
+      module Main
+        class View < Hanami::View
+        end
+      end
+
+      Main::View
+    }
+
+    it "configures the template to match the class name" do
+      expect(template).to eq "view"
+    end
+  end
+
+  context "Deeper Hanami::View subclass" do
+    let(:view_class) {
+      module Main
+        class View < Hanami::View
+        end
+
+        class ArticleIndex < View
+        end
+      end
+
+      Main::ArticleIndex
+    }
+
+    it "configures the tempalte to match the class name" do
+      expect(template).to eq "article_index"
+    end
+  end
+
+  context "Deeper Hanami::View subclass, namespace matching template inference base" do
+    let(:application_hook) {
+      proc do
+        config.views.template_inference_base = "my_views"
+      end
+    }
+
+    let(:view_class) {
+      module Main
+        class View < Hanami::View
+        end
+
+        module MyViews
+          module Articles
+            class Index < View
+            end
+          end
+        end
+      end
+
+      Main::MyViews::Articles::Index
+    }
+
+    it "configures the tempalte to match the class name" do
+      expect(template).to eq "articles/index"
+    end
+  end
+end

--- a/spec/integration/application_view_spec.rb
+++ b/spec/integration/application_view_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe "Application views" do
           config.views.layout = "testing"
         end
       end
+
+      Hanami.application.instance_eval(&application_hook) if respond_to?(:application_hook)
     end
 
     context "Base view defined inside slice" do
@@ -40,11 +42,8 @@ RSpec.describe "Application views" do
 
         Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
 
-        Hanami.application.tap(&application_pre_init_hook)
         Hanami.init
       end
-
-      let(:application_pre_init_hook) { proc { } }
 
       let(:base_view_class) {
         module Main
@@ -67,9 +66,9 @@ RSpec.describe "Application views" do
 
           describe "path" do
             context "relative path provided in application config" do
-              let(:application_pre_init_hook) {
-                proc do |application|
-                  application.config.views.paths = ["templates"]
+              let(:application_hook) {
+                proc do
+                  config.views.paths = ["templates"]
                 end
               }
 
@@ -79,9 +78,9 @@ RSpec.describe "Application views" do
             end
 
             context "absolute path provided in application config" do
-              let(:application_pre_init_hook) {
-                proc do |application|
-                  application.config.views.paths = ["/absolute/path"]
+              let(:application_hook) {
+                proc do
+                  config.views.paths = ["/absolute/path"]
                 end
               }
 
@@ -138,11 +137,8 @@ RSpec.describe "Application views" do
 
     context "Base view defined directly inside application" do
       before do
-        Hanami.application.tap(&application_pre_init_hook)
         Hanami.init
       end
-
-      let(:application_pre_init_hook) { proc { } }
 
       let(:base_view_class) {
         module TestApp
@@ -165,9 +161,9 @@ RSpec.describe "Application views" do
 
           describe "paths" do
             context "relative path provided in application config" do
-              let(:application_pre_init_hook) {
-                proc do |application|
-                  application.config.views.paths = ["templates"]
+              let(:application_hook) {
+                proc do
+                  config.views.paths = ["templates"]
                 end
               }
 
@@ -177,9 +173,9 @@ RSpec.describe "Application views" do
             end
 
             context "absolute path provided in application config" do
-              let(:application_pre_init_hook) {
-                proc do |application|
-                  application.config.views.paths = ["/absolute/path"]
+              let(:application_hook) {
+                proc do
+                  config.views.paths = ["/absolute/path"]
                 end
               }
 

--- a/spec/integration/application_view_spec.rb
+++ b/spec/integration/application_view_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "Application views" do
       module TestApp
         class Application < Hanami::Application
           config.root = "/path/to/app"
-          config.views.template_inference_base = "views"
           config.views.paths = ["templates"]
           config.views.layouts_dir = "test_app_layouts"
           config.views.layout = "testing"
@@ -96,10 +95,6 @@ RSpec.describe "Application views" do
               expect(config.layout).to eq "testing"
             end
           end
-
-          it "does not configure the template" do
-            expect(view_class.config.template).to be_nil
-          end
         end
       end
 
@@ -127,10 +122,6 @@ RSpec.describe "Application views" do
             expect(config.layouts_dir).to eq "test_app_layouts"
             expect(config.layout).to eq "testing"
           end
-        end
-
-        it "configures the template name based on the view's class name, relative to the slice and configured views base_path" do
-          expect(view_class.config.template).to eq "articles/index"
         end
       end
     end
@@ -185,10 +176,6 @@ RSpec.describe "Application views" do
             end
           end
         end
-
-        it "does not configure the template" do
-          expect(view_class.config.template).to be_nil
-        end
       end
 
       describe "subclass of base view class" do
@@ -215,10 +202,6 @@ RSpec.describe "Application views" do
             expect(config.layouts_dir).to eq "test_app_layouts"
             expect(config.layout).to eq "testing"
           end
-        end
-
-        it "configures the template name based on the view's class name, relative to the slice and configured views base_path" do
-          expect(view_class.config.template).to eq "articles/index"
         end
       end
     end


### PR DESCRIPTION
Previously, the `template` setting was only configured on _subclasses_ of an application view, presuming that the initial direct subclass of `Hanami::View` was an abstract “base” view, not to used directly.

This was an overly constricting approach, since there are numerous reasons that an application author may want to inherit directly from `Hanami::View` and use that subclass as a fully renderable view.

This change ensures the `template` setting is configured on _all_ descendants of `Hanami::View`.