### PR TITLE
Add parts_path application config setting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :test do
   gem "erubi"
   gem "hamlit"
   gem "hamlit-block"
-  gem "hanami", github: "hanami/hanami", branch: "use-view-provided-configuration"
+  gem "hanami", github: "hanami/hanami", branch: "unstable"
   gem "hanami-controller", github: "hanami/controller", branch: "unstable"
   gem "hanami-devtools", github: "hanami/devtools"
   gem "rack", ">= 2.0.6"

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :test do
   gem "erubi"
   gem "hamlit"
   gem "hamlit-block"
-  gem "hanami", github: "hanami/hanami", branch: "unstable"
+  gem "hanami", github: "hanami/hanami", branch: "use-view-provided-configuration"
   gem "hanami-controller", github: "hanami/controller", branch: "unstable"
   gem "hanami-devtools", github: "hanami/devtools"
   gem "rack", ">= 2.0.6"

--- a/spec/integration/application_view/part_namespace_spec.rb
+++ b/spec/integration/application_view/part_namespace_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "hanami/view"
+
+RSpec.describe "Application view / Part namespace", :application_integration do
+  subject(:template) { view_class.config.part_namespace }
+
+  before do
+    module TestApp
+      class Application < Hanami::Application
+      end
+    end
+
+    Hanami.application.instance_eval(&application_hook) if respond_to?(:application_hook)
+
+    module Main
+    end
+
+    Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
+
+    Hanami.init
+  end
+
+  context "view in slice" do
+    let(:view_class) {
+      module Main
+        class View < Hanami::View
+        end
+      end
+
+      Main::View
+    }
+
+    context "parts_path configured" do
+      let(:application_hook) {
+        proc do
+          config.views.parts_path = "views/custom_parts"
+        end
+      }
+
+      context "namespace exists" do
+        before do
+          module Main
+            module Views
+              module CustomParts
+              end
+            end
+          end
+        end
+
+        it "is the matching module within the slice" do
+          is_expected.to eq Main::Views::CustomParts
+        end
+      end
+
+      context "namespace exists, but needs requiring" do
+        before do
+          allow_any_instance_of(Object).to receive(:require).and_call_original
+          allow_any_instance_of(Object).to receive(:require).with("main/views/custom_parts") {
+            module Main
+              module Views
+                module CustomParts
+                end
+              end
+            end
+
+            true
+          }
+        end
+
+        it "is the matching module within the slice" do
+          is_expected.to eq Main::Views::CustomParts
+        end
+      end
+
+      context "namespace does not exist" do
+        it "is nil" do
+          is_expected.to be_nil
+        end
+      end
+    end
+
+    context "nil parts_path configured" do
+      let(:application_hook) {
+        proc do
+          config.views.parts_path = nil
+        end
+      }
+
+      it "is nil" do
+        is_expected.to be_nil
+      end
+    end
+  end
+
+  context "view in application" do
+    let(:view_class) {
+      module TestApp
+        class View < Hanami::View
+        end
+      end
+
+      TestApp::View
+    }
+
+    context "parts_path configured" do
+      let(:application_hook) {
+        proc do
+          config.views.parts_path = "views/custom_parts"
+        end
+      }
+
+      context "namespace exists" do
+        before do
+          module TestApp
+            module Views
+              module CustomParts
+              end
+            end
+          end
+        end
+
+        it "is the matching module within the slice" do
+          is_expected.to eq TestApp::Views::CustomParts
+        end
+      end
+
+      context "namespace exists, but needs requiring" do
+        before do
+          allow_any_instance_of(Object).to receive(:require).and_call_original
+          allow_any_instance_of(Object).to receive(:require).with("test_app/views/custom_parts") {
+            module TestApp
+              module Views
+                module CustomParts
+                end
+              end
+            end
+
+            true
+          }
+        end
+
+        it "is the matching module within the slice" do
+          is_expected.to eq TestApp::Views::CustomParts
+        end
+      end
+
+      context "namespace does not exist" do
+        it "is nil" do
+          is_expected.to be_nil
+        end
+      end
+    end
+
+    context "nil parts_path configured" do
+      let(:application_hook) {
+        proc do
+          config.views.parts_path = nil
+        end
+      }
+
+      it "is nil" do
+        is_expected.to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/application_configuration_spec.rb
+++ b/spec/unit/application_configuration_spec.rb
@@ -47,8 +47,30 @@ RSpec.describe Hanami::View::ApplicationConfiguration do
   end
 
   describe "#settings" do
+    it "includes locally defined settings" do
+      expect(configuration.settings).to include :parts_path
+    end
+
     it "includes all view settings apart from inflector" do
-      expect(configuration.settings).to eq Hanami::View.settings - [:inflector]
+      expect(configuration.settings).to include (Hanami::View.settings - [:inflector])
+    end
+  end
+
+  describe "finalized configuration" do
+    before do
+      configuration.finalize!
+    end
+
+    it "is frozen" do
+      expect(configuration).to be_frozen
+    end
+
+    it "does not allow changes to locally defined settings" do
+      expect { configuration.parts_path = "parts" }.to raise_error(Dry::Configurable::FrozenConfig)
+    end
+
+    it "does not allow changes to base view settings" do
+      expect { configuration.paths = [] }.to raise_error(Dry::Configurable::FrozenConfig)
     end
   end
 end


### PR DESCRIPTION
This accepts a value like “views/parts” and is later converted into a `part_namespace` on application views, with the namespace being looked up relative to the view’s containing slice or application. For example, for a view In the `Main` slice, the resulting `part_namespace` would become `Main::Views::Parts`.