### PR TITLE
Custom anonymous scope

### DIFF
--- a/lib/hanami/view/standalone_view.rb
+++ b/lib/hanami/view/standalone_view.rb
@@ -1,3 +1,5 @@
+require_relative "scope"
+
 module Hanami
   class View
     module StandaloneView

--- a/lib/hanami/view/standalone_view.rb
+++ b/lib/hanami/view/standalone_view.rb
@@ -152,6 +152,89 @@ module Hanami
 
         # @!endgroup
 
+        # @!group Scope
+
+        # Creates and assigns a scope for the current view.
+        #
+        # The newly created scope is useful to add custom logic that is specific
+        # to the view.
+        #
+        # The scope has access to locals, exposures, and inherited scope (if any)
+        #
+        # If the view already has an explicit scope the newly created scope will
+        # inherit from the explicit scope.
+        #
+        # There are two cases when this may happen:
+        #   1. The scope was explicitly assigned (e.g. `config.scope = MyScope`)
+        #   2. The scope has been inherited by the view superclass
+        #
+        # If the view doesn't have an already existing scope, the newly scope
+        # will inherit from `Hanami::View::Scope` by default.
+        #
+        # However, you can specify any base class for it. This is not
+        # recommended, unless you know what you're doing.
+        #
+        # @param scope [Hanami::View::Scope] the current scope (if any), or the
+        #   default base class will be `Hanami::View::Scope`
+        # @param block [Proc] the scope logic definition
+        #
+        # @api public
+        #
+        # @example Basic usage
+        #   class MyView < Hanami::View
+        #     config.scope = MyScope
+        #
+        #     scope do
+        #       def greeting
+        #         _locals[:message].upcase + "!"
+        #       end
+        #
+        #       def copyright(time)
+        #         "Copy #{time.year}"
+        #       end
+        #     end
+        #   end
+        #
+        #   # my_view.html.erb
+        #   # <%= greeting %>
+        #   # <%= copyright(Time.now.utc) %>
+        #
+        #   MyView.new.(message: "Hello") # => "HELLO!"
+        #
+        # @example Inherited scope
+        #   class MyScope < Hanami::View::Scope
+        #     private
+        #
+        #     def shout(string)
+        #       string.upcase + "!"
+        #     end
+        #   end
+        #
+        #   class MyView < Hanami::View
+        #     config.scope = MyScope
+        #
+        #     scope do
+        #       def greeting
+        #         shout(_locals[:message])
+        #       end
+        #
+        #       def copyright(time)
+        #         "Copy #{time.year}"
+        #       end
+        #     end
+        #   end
+        #
+        #   # my_view.html.erb
+        #   # <%= greeting %>
+        #   # <%= copyright(Time.now.utc) %>
+        #
+        #   MyView.new.(message: "Hello") # => "HELLO!"
+        def scope(base: config.scope || Hanami::View::Scope, &block)
+          config.scope = Class.new(base, &block)
+        end
+
+        # @!endgroup
+
         # @!group Render environment
 
         # Returns a render environment for the view and the given options. This

--- a/spec/fixtures/integration/scopes/custom_anonymous_scope.html.slim
+++ b/spec/fixtures/integration/scopes/custom_anonymous_scope.html.slim
@@ -1,0 +1,2 @@
+== greeting
+== year(Time.now.utc)


### PR DESCRIPTION
## Feature

Introduce the ability to create custom anonymous scopes for logic that is specific to a view. **This is syntactic sugar to avoid end users to create concrete scope classes**.

Custom anonymous scopes have access to rendering context, locals, exposures, and parts.
The methods defined by custom anonymous scopes are available in templates.

## Examples

### Basic usage

```ruby
class MyView < Hanami::View
  # ... other settings
  scope do
    def greeting
      _locals[:message].upcase + "!"
    end
  end
end

MyView.new.call(message: "Hello") # => "HELLO!"
```

The code above is **equivalent** to the following code, **but it avoids to create a concrete scope class**:

```ruby
class MyScope < Hanami::View::Scope
  def greeting
    _locals[:message].upcase + "!"
  end
end

class MyView < Hanami::View
  config.scope = MyScope.new
end
```

### Inherited scope

If the view is inheriting a scope from a super class, or it already has some explicit scope, then the custom anonymous scope will automatically inherit from it.

```ruby
class ApplicationScope < Hanami::View::Scope
  private

  def formatted_timestamp(time)
    time.strftime("...")
  end
end

class ApplicationView < Hanami::View
  config.scope = ApplicationScope
end

class MyView < ApplicationView
  scope do
    def last_updated_at
      formatted_timestamp(_locals[:article].updated_at)
    end
  end
end

MyView.new.call(article: OpenStruct.new(updated_at: Time.now.utc)) # => "2020-12-23 13:39:57"
```