### PR TITLE
Guard on Array of names being provided with singular value 

### DIFF
--- a/lib/hanami/view/part_builder.rb
+++ b/lib/hanami/view/part_builder.rb
@@ -49,6 +49,10 @@ module Hanami
       private
 
       def build_part(name, value, **options)
+        if options[:as].is_a?(Array)
+          raise ArgumentError, "Unable to use Array for :as when exposing not array-like #{value.class}"
+        end
+
         klass = part_class(name: name, **options)
 
         klass.new(

--- a/spec/unit/part_builder_spec.rb
+++ b/spec/unit/part_builder_spec.rb
@@ -163,6 +163,14 @@ RSpec.describe Hanami::View::PartBuilder do
           expect(part.profile).to be_a Test::Parts::Profile
         end
 
+        describe "alternative names provided via :as option" do
+          let(:options) { {as: [:admin_user, :admin_collection]} }
+
+          it "raises ArgumentError" do
+            expect { part }.to raise_error(ArgumentError, /Unable to use Array for :as/)
+          end
+        end
+
         describe "alternative name provided via :as option" do
           let(:options) { {as: :admin_user} }
 


### PR DESCRIPTION
A singular value will trigger the constantization of the names Array,
which returns an invalid result. The user likely wanted to decorate
an Array-like collection if they were manually providing an array of
names through the `as` option.