### PR TITLE
Raise LayoutNotFoundError when layout is missing

### DIFF
--- a/lib/hanami/view/errors.rb
+++ b/lib/hanami/view/errors.rb
@@ -25,5 +25,20 @@ module Hanami
         super(msg)
       end
     end
+
+    # Error raised when layout could not be found within a view's configured
+    # paths
+    #
+    # @api private
+    class LayoutNotFoundError < StandardError
+      def initialize(layout_name, lookup_paths)
+        msg = [
+          "Layout +#{layout_name}+ could not be found in paths:",
+          lookup_paths.map { |path| " - #{path}" }
+        ].join("\n\n")
+
+        super(msg)
+      end
+    end
   end
 end

--- a/lib/hanami/view/standalone_view.rb
+++ b/lib/hanami/view/standalone_view.rb
@@ -351,10 +351,14 @@ module Hanami
 
           if layout?
             layout_env = self.class.layout_env(format: format, context: context)
-            output = env.template(
-              self.class.layout_path,
-              layout_env.scope(config.scope, layout_locals(locals))
-            ) { output }
+            begin
+              output = env.template(
+                self.class.layout_path,
+                layout_env.scope(config.scope, layout_locals(locals))
+              ) { output }
+            rescue TemplateNotFoundError
+              raise LayoutNotFoundError.new(config.layout, config.paths)
+            end
           end
 
           Rendered.new(output: output, locals: locals)

--- a/spec/unit/view_spec.rb
+++ b/spec/unit/view_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe Hanami::View do
         "<!DOCTYPE html><html><head><title>Test</title></head><body><h1>User</h1><p>Jane</p></body></html>"
       )
     end
+
+    it "raises error when layout cannot be found" do
+      view.config.layout = "invalid"
+      expect { view.(context: context).to_s }.to raise_error Hanami::View::LayoutNotFoundError, /Layout \+invalid\+/
+    end
   end
 
   describe "renderer options" do


### PR DESCRIPTION
This makes the template errors more granular. Layout errors will have their own error which should provide a better "layout missing" error.