### PR TITLE
Use default kwarg in ApplicationConfiguration to fit new dry-configurable API

### DIFF
--- a/lib/hanami/view/application_configuration.rb
+++ b/lib/hanami/view/application_configuration.rb
@@ -8,7 +8,7 @@ module Hanami
     class ApplicationConfiguration
       include Dry::Configurable
 
-      setting :parts_path, "views/parts"
+      setting :parts_path, default: "views/parts"
 
       def initialize(*)
         super


### PR DESCRIPTION
This is a follow-up to #190, as there is still one place that uses old dry-configurable syntax, resulting in a deprecation warning.