### PR TITLE
Require dry-configurable 0.13.0

### DIFF
--- a/hanami-view.gemspec
+++ b/hanami-view.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "dry-configurable", "~> 0.1"
+  spec.add_runtime_dependency "dry-configurable", "~> 0.13", ">= 0.13.0"
   spec.add_runtime_dependency "dry-core", "~> 0.5", ">= 0.5"
   spec.add_runtime_dependency "dry-inflector", "~> 0.1"
   spec.add_runtime_dependency "tilt", "~> 2.0", ">= 2.0.6"


### PR DESCRIPTION
We're using its new `setting` API now.