### PR TITLE
Fix test suite by adding hanami/router as test dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :test do
   gem "hanami-cli", github: "hanami/cli", branch: "main"
   gem "hanami", github: "hanami/hanami", branch: "main"
   gem "hanami-controller", github: "hanami/controller", branch: "main"
+  gem "hanami-router", github: "hanami/router", branch: "main"
   gem "hanami-devtools", github: "hanami/devtools", branch: "main"
   gem "rack", ">= 2.0.6"
   gem "slim", "~> 4.0"


### PR DESCRIPTION
Since https://github.com/hanami/hanami/pull/1119, it's required whan
integrating with the hanami framework