### PR TITLE
Change default templates path to just `templates/`

### DIFF
--- a/lib/hanami/view/application_configuration.rb
+++ b/lib/hanami/view/application_configuration.rb
@@ -41,7 +41,7 @@ module Hanami
       attr_reader :base_config
 
       def configure_defaults
-        self.paths = ["web/templates"]
+        self.paths = ["templates"]
         self.template_inference_base = "views"
         self.layout = "application"
       end

--- a/spec/unit/application_configuration_spec.rb
+++ b/spec/unit/application_configuration_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe Hanami::View::ApplicationConfiguration do
 
   describe "specialised default values" do
     describe "paths" do
-      it 'is ["web/templates"]' do
+      it 'is ["templates"]' do
         expect(configuration.paths).to match [
-          an_object_satisfying { |path| path.dir.to_s == "web/templates" }
+          an_object_satisfying { |path| path.dir.to_s == "templates" }
         ]
       end
     end


### PR DESCRIPTION
Pretty self-explanatory! Almost all HTML templates are for the web, so we don't need to specify it by default.