### PR TITLE
Views structure

### DIFF
--- a/lib/hanami/view.rb
+++ b/lib/hanami/view.rb
@@ -235,9 +235,10 @@ module Hanami
     def self.inherited(subclass)
       super
 
-      # If inheriting directly from Hanami::View within an Hanami app, configure
-      # the view for the application
-      if subclass.superclass == View && (provider = application_provider(subclass))
+      # When inheriting within an Hanami app, and the application provider has
+      # changed from the superclass, (re-)configure the action for the provider,
+      # i.e. for the slice and/or the application itself
+      if (provider = application_provider(subclass)) && provider != application_provider(subclass.superclass)
         subclass.include ApplicationView.new(provider)
       end
     end

--- a/lib/hanami/view/application_configuration.rb
+++ b/lib/hanami/view/application_configuration.rb
@@ -41,7 +41,7 @@ module Hanami
       attr_reader :base_config
 
       def configure_defaults
-        self.paths = ["web/templates"]
+        self.paths = ["templates"]
         self.template_inference_base = "views"
         self.layout = "application"
       end

--- a/lib/hanami/view/application_configuration.rb
+++ b/lib/hanami/view/application_configuration.rb
@@ -8,7 +8,7 @@ module Hanami
     class ApplicationConfiguration
       include Dry::Configurable
 
-      setting :parts_path, default: "views/parts"
+      setting :parts_path, default: "view/parts"
 
       def initialize(*)
         super

--- a/lib/hanami/view/errors.rb
+++ b/lib/hanami/view/errors.rb
@@ -2,6 +2,11 @@
 
 module Hanami
   class View
+    # @since 2.0.0
+    # @api public
+    class Error < StandardError
+    end
+
     # Error raised when critical settings are not configured
     #
     # @api private
@@ -38,6 +43,14 @@ module Hanami
         ].join("\n\n")
 
         super(msg)
+      end
+    end
+
+    # @since 2.0.0
+    # @api public
+    class MissingProviderError < Error
+      def initialize(provider)
+        super("#{provider.inspect} is missing")
       end
     end
   end

--- a/spec/integration/application_view/inflector_spec.rb
+++ b/spec/integration/application_view/inflector_spec.rb
@@ -17,17 +17,26 @@ RSpec.describe "Application view / Inflector", :application_integration do
 
     Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
     Hanami.prepare
+
+    module TestApp
+      module View
+        class Base < Hanami::View
+        end
+      end
+    end
   end
 
   let(:application_class_config) { proc {} }
 
   subject(:view_class) {
     module Main
-      class View < Hanami::View
+      module View
+        class Base < TestApp::View::Base
+        end
       end
     end
 
-    Main::View
+    Main::View::Base
   }
 
   context "no application inflector configured" do

--- a/spec/integration/application_view/part_namespace_spec.rb
+++ b/spec/integration/application_view/part_namespace_spec.rb
@@ -20,29 +20,38 @@ RSpec.describe "Application view / Part namespace", :application_integration do
     Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
 
     Hanami.prepare
+
+    module TestApp
+      module View
+        class Base < Hanami::View
+        end
+      end
+    end
   end
 
   context "view in slice" do
     let(:view_class) {
       module Main
-        class View < Hanami::View
+        module View
+          class Base < TestApp::View::Base
+          end
         end
       end
 
-      Main::View
+      Main::View::Base
     }
 
     context "parts_path configured" do
       let(:application_hook) {
         proc do
-          config.views.parts_path = "views/custom_parts"
+          config.views.parts_path = "view/custom_parts"
         end
       }
 
       context "namespace exists" do
         before do
           module Main
-            module Views
+            module View
               module CustomParts
               end
             end
@@ -50,16 +59,16 @@ RSpec.describe "Application view / Part namespace", :application_integration do
         end
 
         it "is the matching module within the slice" do
-          is_expected.to eq Main::Views::CustomParts
+          is_expected.to eq Main::View::CustomParts
         end
       end
 
       context "namespace exists, but needs requiring" do
         before do
           allow_any_instance_of(Object).to receive(:require).and_call_original
-          allow_any_instance_of(Object).to receive(:require).with("main/views/custom_parts") {
+          allow_any_instance_of(Object).to receive(:require).with("main/view/custom_parts") {
             module Main
-              module Views
+              module View
                 module CustomParts
                 end
               end
@@ -70,7 +79,7 @@ RSpec.describe "Application view / Part namespace", :application_integration do
         end
 
         it "is the matching module within the slice" do
-          is_expected.to eq Main::Views::CustomParts
+          is_expected.to eq Main::View::CustomParts
         end
       end
 
@@ -95,43 +104,37 @@ RSpec.describe "Application view / Part namespace", :application_integration do
   end
 
   context "view in application" do
-    let(:view_class) {
-      module TestApp
-        class View < Hanami::View
-        end
-      end
-
-      TestApp::View
-    }
+    let(:view_class) { TestApp::View::Base }
 
     context "parts_path configured" do
       let(:application_hook) {
         proc do
-          config.views.parts_path = "views/custom_parts"
+          config.views.parts_path = "view/custom_parts"
         end
       }
 
       context "namespace exists" do
         before do
           module TestApp
-            module Views
+            module View
               module CustomParts
               end
             end
           end
         end
 
-        it "is the matching module within the slice" do
-          is_expected.to eq TestApp::Views::CustomParts
+        # FIXME: @jodosha ask @timriley
+        xit "is the matching module within the slice" do
+          is_expected.to eq TestApp::View::CustomParts
         end
       end
 
       context "namespace exists, but needs requiring" do
         before do
           allow_any_instance_of(Object).to receive(:require).and_call_original
-          allow_any_instance_of(Object).to receive(:require).with("test_app/views/custom_parts") {
+          allow_any_instance_of(Object).to receive(:require).with("test_app/view/custom_parts") {
             module TestApp
-              module Views
+              module View
                 module CustomParts
                 end
               end
@@ -141,8 +144,9 @@ RSpec.describe "Application view / Part namespace", :application_integration do
           }
         end
 
-        it "is the matching module within the slice" do
-          is_expected.to eq TestApp::Views::CustomParts
+        # FIXME: @jodosha ask @timriley
+        xit "is the matching module within the slice" do
+          is_expected.to eq TestApp::View::CustomParts
         end
       end
 

--- a/spec/integration/application_view/part_namespace_spec.rb
+++ b/spec/integration/application_view/part_namespace_spec.rb
@@ -4,7 +4,7 @@ require "hanami"
 require "hanami/view"
 
 RSpec.describe "Application view / Part namespace", :application_integration do
-  subject(:template) { view_class.config.part_namespace }
+  subject(:part_namespace) { view_class.config.part_namespace }
 
   before do
     module TestApp
@@ -14,23 +14,20 @@ RSpec.describe "Application view / Part namespace", :application_integration do
 
     Hanami.application.instance_eval(&application_hook) if respond_to?(:application_hook)
 
-    module Main
-    end
-
+    module Main; end
     Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
 
     Hanami.prepare
-
-    module TestApp
-      module View
-        class Base < Hanami::View
-        end
-      end
-    end
   end
 
   context "view in slice" do
     let(:view_class) {
+      module TestApp
+        module View
+          class Base < Hanami::View; end
+        end
+      end
+
       module Main
         module View
           class Base < TestApp::View::Base
@@ -104,7 +101,15 @@ RSpec.describe "Application view / Part namespace", :application_integration do
   end
 
   context "view in application" do
-    let(:view_class) { TestApp::View::Base }
+    let(:view_class) {
+      module TestApp
+        module View
+          class Base < Hanami::View; end
+        end
+      end
+
+      TestApp::View::Base
+    }
 
     context "parts_path configured" do
       let(:application_hook) {
@@ -123,8 +128,7 @@ RSpec.describe "Application view / Part namespace", :application_integration do
           end
         end
 
-        # FIXME: @jodosha ask @timriley
-        xit "is the matching module within the slice" do
+        it "is the matching module within the slice" do
           is_expected.to eq TestApp::View::CustomParts
         end
       end
@@ -144,8 +148,7 @@ RSpec.describe "Application view / Part namespace", :application_integration do
           }
         end
 
-        # FIXME: @jodosha ask @timriley
-        xit "is the matching module within the slice" do
+        it "is the matching module within the slice" do
           is_expected.to eq TestApp::View::CustomParts
         end
       end

--- a/spec/integration/application_view/template_spec.rb
+++ b/spec/integration/application_view/template_spec.rb
@@ -20,42 +20,58 @@ RSpec.describe "Application view / Template", :application_integration do
     Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
 
     Hanami.prepare
-  end
 
-  context "Direct Hanami::View subclass" do
-    let(:view_class) {
-      module Main
-        class View < Hanami::View
+    module TestApp
+      module View
+        class Base < Hanami::View
         end
       end
+    end
 
-      Main::View
-    }
-
-    it "configures the template to match the class name" do
-      expect(template).to eq "view"
+    module Main
+      module View
+        class Base < TestApp::View::Base
+        end
+      end
     end
   end
 
-  context "Deeper Hanami::View subclass" do
+  context "Application base view" do
+    let(:view_class) { TestApp::View::Base }
+
+    it "configures the template to match the class name" do
+      expect(template).to eq "view/base"
+    end
+  end
+
+  context "Slice base view" do
+    let(:view_class) { Main::View::Base }
+
+    it "configures the template to match the class name" do
+      expect(template).to eq "main/view/base"
+    end
+  end
+
+  context "Slice view" do
     let(:view_class) {
       module Main
-        class View < Hanami::View
-        end
-
-        class ArticleIndex < View
+        module Views
+          module Article
+            class Index < View::Base
+            end
+          end
         end
       end
 
-      Main::ArticleIndex
+      Main::Views::Article::Index
     }
 
     it "configures the tempalte to match the class name" do
-      expect(template).to eq "article_index"
+      expect(template).to eq "article/index"
     end
   end
 
-  context "Deeper Hanami::View subclass, namespace matching template inference base" do
+  context "Slice view with namespace matching template inference base" do
     let(:application_hook) {
       proc do
         config.views.template_inference_base = "my_views"
@@ -64,22 +80,19 @@ RSpec.describe "Application view / Template", :application_integration do
 
     let(:view_class) {
       module Main
-        class View < Hanami::View
-        end
-
         module MyViews
-          module Articles
-            class Index < View
+          module Users
+            class Show < View::Base
             end
           end
         end
       end
 
-      Main::MyViews::Articles::Index
+      Main::MyViews::Users::Show
     }
 
     it "configures the tempalte to match the class name" do
-      expect(template).to eq "articles/index"
+      expect(template).to eq "users/show"
     end
   end
 end

--- a/spec/integration/application_view_spec.rb
+++ b/spec/integration/application_view_spec.rb
@@ -42,15 +42,24 @@ RSpec.describe "Application views" do
         Hanami.application.register_slice :main, namespace: Main, root: "/path/to/app/slices/main"
 
         Hanami.prepare
+
+        module TestApp
+          module View
+            class Base < Hanami::View
+            end
+          end
+        end
       end
 
       let(:base_view_class) {
         module Main
-          class View < Hanami::View
+          module View
+            class Base < TestApp::View::Base
+            end
           end
         end
 
-        Main::View
+        Main::View::Base
       }
 
       describe "base view class" do
@@ -105,7 +114,7 @@ RSpec.describe "Application views" do
           module Main
             module Views
               module Articles
-                class Index < Main::View
+                class Index < Main::View::Base
                 end
               end
             end

--- a/spec/integration/context/application_context/assets_spec.rb
+++ b/spec/integration/context/application_context/assets_spec.rb
@@ -1,0 +1,69 @@
+require "hanami"
+require "hanami/view/context"
+
+RSpec.describe "Application context / Assets", :application_integration do
+  before do
+    module TestApp
+      class Application < Hanami::Application
+      end
+    end
+
+    Hanami.prepare
+  end
+
+  let(:context_class) {
+    module TestApp
+      module View
+        class Context < Hanami::View::Context
+        end
+      end
+    end
+    TestApp::View::Context
+  }
+
+  subject(:context) {
+    context_class.new
+  }
+
+  describe "#assets" do
+    context "without assets provider" do
+      it "raises error" do
+        expect { context.assets }.to raise_error(Hanami::View::MissingProviderError, /hanami-assets/)
+      end
+    end
+
+    context "with assets provider" do
+      before do
+        Hanami.application.register_provider(:assets) do
+          start do
+            register "assets", Object.new
+          end
+        end
+      end
+
+      it "is the application assets by default" do
+        expect(context.assets).to be TestApp::Application[:assets]
+      end
+
+      context "injected assets" do
+        subject(:context) {
+          context_class.new(assets: assets)
+        }
+
+        let(:assets) { double(:assets) }
+
+        it "is the injected assets" do
+          expect(context.assets).to be assets
+        end
+
+        context "rebuilt context" do
+          subject(:new_context) { context.with }
+
+          it "retains the injected assets" do
+            expect(new_context.assets).to be assets
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/context/application_context/settings_spec.rb
+++ b/spec/integration/context/application_context/settings_spec.rb
@@ -1,0 +1,53 @@
+require "hanami"
+require "hanami/view/context"
+
+RSpec.describe "Application context / Settings", :application_integration do
+  before do
+    module TestApp
+      class Application < Hanami::Application
+      end
+    end
+
+    Hanami.prepare
+  end
+
+  let(:context_class) {
+    module TestApp
+      module View
+        class Context < Hanami::View::Context
+        end
+      end
+    end
+    TestApp::View::Context
+  }
+
+  subject(:context) {
+    context_class.new
+  }
+
+  describe "#settings" do
+    it "is the application settings by default" do
+      expect(context.settings).to be TestApp::Application.settings
+    end
+
+    context "injected settings" do
+      subject(:context) {
+        context_class.new(settings: settings)
+      }
+
+      let(:settings) { double(:settings) }
+
+      it "is the injected settings" do
+        expect(context.settings).to be settings
+      end
+
+      context "rebuilt context" do
+        subject(:new_context) { context.with }
+
+        it "retains the injected settings" do
+          expect(new_context.settings).to be settings
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/application_configuration_spec.rb
+++ b/spec/unit/application_configuration_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Hanami::View::ApplicationConfiguration do
     describe "paths" do
       it 'is ["web/templates"]' do
         expect(configuration.paths).to match [
-          an_object_satisfying { |path| path.dir.to_s == "web/templates" }
+          an_object_satisfying { |path| path.dir.to_s == "templates" }
         ]
       end
     end


### PR DESCRIPTION
## Enhancements

  * Inject app `settings` and `assets` (if bundled) into `Hanami::View::ApplicationContext`
  * Temporary ported from `hanami/hanami-2-application-template` a few helpers: `#content_for`, `#current_path` `#csrf_token`. Some of those helpers will be moved to `hanami-helpers` gem.

## Fixes

  * Ensure `Hanami::View::ApplicationView` to handle deep inheritance chain (app base view -> slice base view -> slice view) https://github.com/hanami/view/pull/203/commits/a01d0a9e88f5510f1e0a6c181ef82c9c59b344f0 

## Changes

  * Default parts namespace is now `view/parts` (it was `views/parts`)
  * [internal] Changed the integration specs to reflect the new Views structure (see https://github.com/hanami/hanami-2-application-template/pull/76)

---

Ref https://github.com/hanami/hanami/pull/1151
Ref https://github.com/hanami/hanami-2-application-template/pull/76