### PR TITLE
Ensure proper access to full `locals` hash in templates

### DIFF
--- a/lib/hanami/view/renderer.rb
+++ b/lib/hanami/view/renderer.rb
@@ -46,7 +46,7 @@ module Hanami
       end
 
       def render(path, scope, &block)
-        tilt(path).render(scope, &block)
+        tilt(path).render(scope, {locals: scope._locals}, &block)
       end
 
       def chdir(dirname)

--- a/lib/hanami/view/scope.rb
+++ b/lib/hanami/view/scope.rb
@@ -35,7 +35,7 @@ module Hanami
       # @overload _locals
       #   Returns the locals
       # @overload locals
-      #   A convenience alias for `#_format.` Is available unless there is a
+      #   A convenience alias for `#_locals.` Is available unless there is a
       #   local named `locals`
       #
       # @return [Hash[<Symbol, Object>]

--- a/spec/fixtures/integration/template_rendering/locals/locals_in_template.html.slim
+++ b/spec/fixtures/integration/template_rendering/locals/locals_in_template.html.slim
@@ -1,0 +1,1 @@
+== "Locals: #{locals.inspect}"

--- a/spec/integration/template_rendering/locals_spec.rb
+++ b/spec/integration/template_rendering/locals_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe "Tempalte rendering / locals" do
+  let(:base_view) {
+    Class.new(Hanami::View) do
+      config.paths = FIXTURES_PATH.join("integration/template_rendering/locals")
+    end
+  }
+
+  specify "Accessing all `locals` inside template" do
+    view = Class.new(base_view) do
+      config.template = "locals_in_template"
+
+      expose :text, decorate: false
+    end.new
+
+    expect(view.(text: "Hello").to_s).to eq %{Locals: {:text=>"Hello"}}
+  end
+end

--- a/spec/unit/renderer_spec.rb
+++ b/spec/unit/renderer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hanami::View::Renderer do
     )
   end
 
-  let(:scope) { double(:scope) }
+  let(:scope) { double(:scope, _locals: {}) }
 
   describe "#template" do
     it "renders template in current directory" do


### PR DESCRIPTION
This _should_ already have worked, thanks to the `method_missing`-based `#locals` method that we expose in `Hanami::View::Scope`.

However, `locals` in in fact a _local variable_ in the template rendering context, since that's the name of the one and only parameter for the method that Tilt compiles each template into. This means we can't access the `#locals` on our `Scope` instance without explicitly calling `self.locals`.

To fix this, we pass our `scope._locals` additionally into Tilt's `render` method, which will allow bare `locals` references to work inside templates.

Since this behavior evaded detection for so many years, we now have a dedicated test to make sure it remains working like we expect in the future.