### PR TITLE
Include format in MissingTemplateError

### DIFF
--- a/lib/hanami/view/errors.rb
+++ b/lib/hanami/view/errors.rb
@@ -23,7 +23,7 @@ module Hanami
     class TemplateNotFoundError < StandardError
       def initialize(template_name, format, lookup_paths)
         msg = [
-          "Template +#{template_name}+ for format +#{format}+ could not be found in paths:",
+          "Template `#{template_name}' for format `#{format}' could not be found in paths:",
           lookup_paths.map { |path| " - #{path}" }
         ].join("\n\n")
 

--- a/lib/hanami/view/errors.rb
+++ b/lib/hanami/view/errors.rb
@@ -21,9 +21,9 @@ module Hanami
     #
     # @api private
     class TemplateNotFoundError < StandardError
-      def initialize(template_name, lookup_paths)
+      def initialize(template_name, format, lookup_paths)
         msg = [
-          "Template +#{template_name}+ could not be found in paths:",
+          "Template +#{template_name}+ for format +#{format}+ could not be found in paths:",
           lookup_paths.map { |path| " - #{path}" }
         ].join("\n\n")
 

--- a/lib/hanami/view/renderer.rb
+++ b/lib/hanami/view/renderer.rb
@@ -31,7 +31,7 @@ module Hanami
         if path
           render(path, scope, &block)
         else
-          raise TemplateNotFoundError.new(name, paths)
+          raise TemplateNotFoundError.new(name, format, paths)
         end
       end
 

--- a/spec/unit/renderer_spec.rb
+++ b/spec/unit/renderer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Hanami::View::Renderer do
     it "raises error when template cannot be found" do
       expect {
         renderer.template(:missing_template, scope)
-      }.to raise_error(Hanami::View::TemplateNotFoundError, /missing_template/)
+      }.to raise_error(Hanami::View::TemplateNotFoundError, /missing_template.*html/)
     end
   end
 


### PR DESCRIPTION
This will now show an error such as:

```
Puma caught this error: Template +books/show+ for format +html+ could not be found in paths:

 - /Users/ryan.bigg/code/playground/bookshelf/app/templates
```

Fixes https://trello.com/c/QqyDKhjq/177-hanami-view-template-not-found-errors-should-include-what-format-it-is-using-to-look-for-them
