### PR TITLE
Add configurable part_class and scope_class settings

### DIFF
--- a/lib/hanami/view.rb
+++ b/lib/hanami/view.rb
@@ -10,6 +10,7 @@ require_relative "view/context"
 require_relative "view/exposures"
 require_relative "view/errors"
 require_relative "view/html"
+require_relative "view/part"
 require_relative "view/part_builder"
 require_relative "view/path"
 require_relative "view/rendered"
@@ -140,6 +141,8 @@ module Hanami
     #   @api public
     # @!scope class
     setting :default_format, default: :html
+
+    setting :part_class, default: Part
 
     # @overload config.scope_namespace=(namespace)
     #   Set a namespace that will be searched when building scope classes.

--- a/lib/hanami/view.rb
+++ b/lib/hanami/view.rb
@@ -16,6 +16,7 @@ require_relative "view/path"
 require_relative "view/rendered"
 require_relative "view/renderer"
 require_relative "view/rendering"
+require_relative "view/scope"
 require_relative "view/scope_builder"
 
 module Hanami
@@ -164,6 +165,8 @@ module Hanami
     #   @api public
     # @!scope class
     setting :part_builder, default: PartBuilder
+
+    setting :scope_class, default: Scope
 
     # @overload config.scope_namespace=(namespace)
     #   Set a namespace that will be searched when building scope classes.
@@ -453,8 +456,10 @@ module Hanami
     #   # <%= copyright(Time.now.utc) %>
     #
     #   MyView.new.(message: "Hello") # => "HELLO!"
-    def self.scope(base: config.scope || Hanami::View::Scope, &block)
-      config.scope = Class.new(base, &block)
+    def self.scope(scope_class = nil, &block)
+      scope_class ||= config.scope || config.scope_class
+
+      config.scope = Class.new(scope_class, &block)
     end
 
     # @!endgroup

--- a/spec/integration/part_builder_spec.rb
+++ b/spec/integration/part_builder_spec.rb
@@ -19,7 +19,33 @@ RSpec.describe "part builder" do
     end
   end
 
-  describe "default decorator" do
+  describe "default part builder" do
+    it "defaults to creating instances of Hanami::View::Part" do
+      view = Class.new(Hanami::View) do
+        config.paths = SPEC_ROOT.join("__ignore__")
+        config.template = "__ignore__"
+      end.new
+
+      part = view.rendering.part(:my_part, Object.new)
+
+      expect(part).to be_an_instance_of Hanami::View::Part
+    end
+
+    it "create instances of a configured part_class" do
+      part_class = Class.new(Hanami::View::Part)
+
+      view = Class.new(Hanami::View) do
+        config.paths = SPEC_ROOT.join("__ignore__")
+        config.template = "__ignore__"
+
+        config.part_class = part_class
+      end.new
+
+      part = view.rendering.part(:my_part, Object.new)
+
+      expect(part).to be_an_instance_of part_class
+    end
+
     it "looks up classes from a part namespace" do
       view = Class.new(Hanami::View) do
         config.paths = SPEC_ROOT.join("fixtures/templates")
@@ -37,7 +63,7 @@ RSpec.describe "part builder" do
       )
     end
 
-    it "supports wrapping array members in custom part classes provided to exposure :as option" do
+    it "wraps array members in custom part classes provided to exposure :as option" do
       view = Class.new(Hanami::View) do
         config.paths = SPEC_ROOT.join("fixtures/templates")
         config.layout = nil
@@ -53,7 +79,7 @@ RSpec.describe "part builder" do
       )
     end
 
-    it "supports wrapping an array and its members in custom part classes provided to exposure :as option as an array" do
+    it "wraps an array and its members in custom part classes provided to exposure :as option as an array" do
       view = Class.new(Hanami::View) do
         config.paths = SPEC_ROOT.join("fixtures/templates")
         config.layout = nil
@@ -70,7 +96,7 @@ RSpec.describe "part builder" do
     end
   end
 
-  describe "custom decorator and part classes" do
+  describe "custom part builder and part classes" do
     it "supports wrapping in custom parts based on exposure names" do
       part_builder = Class.new(Hanami::View::PartBuilder) do
         class << self

--- a/spec/integration/scope_builder_spec.rb
+++ b/spec/integration/scope_builder_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe "scope builder" do
+  describe "default scope builder" do
+    it "defaults to creating instances of Hanami::View::Scope" do
+      view = Class.new(Hanami::View) do
+        config.paths = SPEC_ROOT.join("__ignore__")
+        config.template = "__ignore__"
+      end.new
+
+      scope = view.rendering.scope({})
+
+      expect(scope).to be_an_instance_of Hanami::View::Scope
+    end
+
+    it "create instances of a configured scope_class" do
+      scope_class = Class.new(Hanami::View::Scope)
+
+      view = Class.new(Hanami::View) do
+        config.paths = SPEC_ROOT.join("__ignore__")
+        config.template = "__ignore__"
+
+        config.scope_class = scope_class
+      end.new
+
+      scope = view.rendering.scope({})
+
+      expect(scope).to be_an_instance_of scope_class
+    end
+  end
+end


### PR DESCRIPTION
Add `part_class` and `scope_class` settings, used by the `part_builder` and `scope_builder` respectively as the default class to use when no value-specific part or scope classes can be found.

These settings default to `Hanami::View::Part` and `Hanami::View::Scope` respectively, so there is no change to hanami-view's behaviour when not explicitly configured.

The reason we're adding these settings, however, is so that full Hanami apps may configured their own custom `part_class` and `scope_class`, providing classes that have mixed in a range of helper modules.