### PR TITLE
Mark blocks captured from templates as HTML safe

### DIFF
--- a/lib/hanami/view/erb/engine.rb
+++ b/lib/hanami/view/erb/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "temple"
+require_relative "../html_safe_string_buffer"
 
 module Hanami
   class View
@@ -14,6 +15,8 @@ module Hanami
       # @api private
       # @since 2.0.0
       class Engine < Temple::Engine
+        define_options capture_generator: Hanami::View::HTMLSafeStringBuffer
+
         use Parser
         use Filters::Block
         use Filters::Trimming

--- a/lib/hanami/view/haml/template.rb
+++ b/lib/hanami/view/haml/template.rb
@@ -1,11 +1,27 @@
 # frozen_string_literal: true
 
 require "haml"
+require_relative "../html_safe_string_buffer"
 
 module Hanami
   class View
     # @api private
     module HamlAdapter
+      # Add options to Haml::Engine to match the options from its default generator.
+      #
+      # The default generator for Haml::Engine is configurable via an engine option, like so:
+      #
+      # use :Generator, -> { options[:generator] }
+      #
+      # Because this Temple filter is set as a proc, the resulting effect within Temple's EngineDSL
+      # is that the generator's valid options are not merged into the full set of options available
+      # on Haml::Engine itself. This means we receive a "Option :capture_generator is invalid"
+      # warning when we set our `capture_generator:` below.
+      #
+      # However, this option is perfectly valid, so here we merge all the options for Haml's default
+      # generator into the top-level engine's options, avoiding the warning.
+      ::Haml::Engine.define_options(::Haml::Engine.options[:generator].options.valid_keys)
+
       # Haml template renderer for Hanami::View.
       #
       # This differs from the standard Haml::Template by automatically escaping HTML based on a
@@ -13,7 +29,11 @@ module Hanami
       #
       # @see Hanami::View::Tilt
       # @api private
-      Template = Temple::Templates::Tilt(::Haml::Engine, use_html_safe: true)
+      Template = Temple::Templates::Tilt(
+        ::Haml::Engine,
+        use_html_safe: true,
+        capture_generator: HTMLSafeStringBuffer,
+      )
     end
   end
 end

--- a/lib/hanami/view/html_safe_string_buffer.rb
+++ b/lib/hanami/view/html_safe_string_buffer.rb
@@ -38,6 +38,17 @@ module Hanami
     # @api private
     # @since 2.0.0
     class HTMLSafeStringBuffer < Temple::Generators::StringBuffer
+      # Replace `Temple::Generator::ArrayBuffer#call` (which is used via the superclass of
+      # `StringBuffer`) with the standard implementation from the base `Temple::Generator`.
+      #
+      # This avoids certain specialisations in `ArrayBuffer#call` that prevent `#return_buffer` from
+      # being called. For our needs, `#return_buffer` must be called at all times in order to ensure
+      # the captured string is consistently marked as `.html_safe`.
+      def call(exp)
+        [preamble, compile(exp), postamble].flatten.compact.join('; ')
+      end
+
+      # Marks the string returned from the captured buffer as HTML safe.
       def return_buffer
         "#{buffer}.html_safe"
       end

--- a/lib/hanami/view/html_safe_string_buffer.rb
+++ b/lib/hanami/view/html_safe_string_buffer.rb
@@ -2,13 +2,19 @@
 
 require "temple"
 
-# Add temple patch from https://github.com/judofyr/temple/pull/113 (which was since rolled back) to
-# demonstrate the need for the `:capture_generator` setting value to be propogated in order to
-# consistently handle nested captures.
-module Temple
-  class Generator
-    def on_capture(name, exp)
-      capture_generator.new(**options, buffer: name).call(exp)
+if Temple::VERSION <= "0.10.0"
+  # Include the (already merged) change from https://github.com/judofyr/temple/pull/144 so
+  # hanami-view can be tested with already released versions of Temple.
+  #
+  # TODO: Remove this patch after the next release of Temple (>0.10.0) and before the hanami-view
+  # 2.0 release.
+  module Temple
+    class Generator
+      undef_method :on_capture # Avoid method redefinition warnings
+
+      def on_capture(name, exp)
+        capture_generator.new(**options, buffer: name).call(exp)
+      end
     end
   end
 end

--- a/lib/hanami/view/html_safe_string_buffer.rb
+++ b/lib/hanami/view/html_safe_string_buffer.rb
@@ -2,6 +2,17 @@
 
 require "temple"
 
+# Add temple patch from https://github.com/judofyr/temple/pull/113 (which was since rolled back) to
+# demonstrate the need for the `:capture_generator` setting value to be propogated in order to
+# consistently handle nested captures.
+module Temple
+  class Generator
+    def on_capture(name, exp)
+      capture_generator.new(**options, buffer: name).call(exp)
+    end
+  end
+end
+
 module Hanami
   class View
     # Speicalized Temple buffer class that marks block-captured strings as HTML safe.

--- a/lib/hanami/view/html_safe_string_buffer.rb
+++ b/lib/hanami/view/html_safe_string_buffer.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "temple"
+
+module Hanami
+  class View
+    # Speicalized Temple buffer class that marks block-captured strings as HTML safe.
+    #
+    # This is important for any scope or part methods that receive a string from a yielded block
+    # and then determine whether to escape that string based on its `.html_safe?` value.
+    #
+    # In this case, since blocks captured templates _intentionally_ contain HTML (this is the
+    # purpose of the template after all), it makes sense to mark the entire captured block string as
+    # HTML safe.
+    #
+    # This is compatible with escaping of values interpolated into the template, since those will
+    # have already been automatically escaped by the template engine when they are evaluated, before
+    # the overall block is captured.
+    #
+    # This filter is included in all three of our supported HTML template engines (ERB, Haml and
+    # Slim) to provide consistent behavior across all.
+    #
+    # @see Hanami::View::ERB::Engine
+    # @see Hanami::View::HamlAdapter::Template
+    # @see Hanami::View::SlimAdapter::Template
+    #
+    # @api private
+    # @since 2.0.0
+    class HTMLSafeStringBuffer < Temple::Generators::StringBuffer
+      def return_buffer
+        "#{buffer}.html_safe"
+      end
+    end
+  end
+end

--- a/lib/hanami/view/slim/template.rb
+++ b/lib/hanami/view/slim/template.rb
@@ -1,11 +1,27 @@
 # frozen_string_literal: true
 
 require "slim"
+require_relative "../html_safe_string_buffer"
 
 module Hanami
   class View
     # @api private
     module SlimAdapter
+      # Add options to Slim::Engine to match the options from its default generator.
+      #
+      # The default generator for Slim::Engine is configurable via an engine option, like so:
+      #
+      # use(:Generator) { options[:generator] }
+      #
+      # Because this Temple filter is set as a proc, the resulting effect within Temple's EngineDSL
+      # is that the generator's valid options are not merged into the full set of options available
+      # on Slim::Engine itself. This means we receive a "Option :capture_generator is invalid"
+      # warning when we set our `capture_generator:` below.
+      #
+      # However, this option is perfectly valid, so here we merge all the options for Slim's default
+      # generator into the top-level engine's options, avoiding the warning.
+      ::Slim::Engine.define_options(::Slim::Engine.options[:generator].options.valid_keys)
+
       # Slim template renderer for Hanami::View.
       #
       # This differs from the standard Slim::Template by automatically escaping HTML based on a
@@ -13,7 +29,11 @@ module Hanami
       #
       # @see Hanami::View::Tilt
       # @api private
-      Template = Temple::Templates::Tilt(::Slim::Engine, use_html_safe: true)
+      Template = Temple::Templates::Tilt(
+        ::Slim::Engine,
+        use_html_safe: true,
+        capture_generator: HTMLSafeStringBuffer,
+      )
     end
   end
 end

--- a/spec/integration/erb/erb_spec.rb
+++ b/spec/integration/erb/erb_spec.rb
@@ -199,6 +199,25 @@ RSpec.describe Hanami::View::ERB::Template do
     HTML
   end
 
+  it "marks captured block content as HTML safe" do
+    scope = Class.new {
+      def html_safe_capture
+        yield.html_safe?
+      end
+    }.new
+
+    src = <<~ERB
+      <%= html_safe_capture do %>
+        <div>Some content</div>
+        <div>goes here.</div>
+      <% end %>
+    ERB
+
+    output = render(src, scope)
+
+    expect(output.strip).to eq "true"
+  end
+
   it "supports case expressions" do
     # Case expressions need this unconventional opening tag to work in ERB; see this 2009 gist for
     # more: https://gist.github.com/davidphasson/91613

--- a/spec/integration/erb/erb_spec.rb
+++ b/spec/integration/erb/erb_spec.rb
@@ -218,6 +218,33 @@ RSpec.describe Hanami::View::ERB::Template do
     expect(output.strip).to eq "true"
   end
 
+  it "marks nested captured blocks as HTML safe" do
+    scope = Class.new {
+      def html_safe_capture
+        captured = yield
+        safe = captured.html_safe?
+
+        "#{safe}: #{captured.strip}".then { |str| safe ? str.html_safe : str }
+      end
+    }.new
+
+    src = <<~ERB
+      <%= html_safe_capture do %>
+        <div>Some content here.</div>
+        <%= html_safe_capture do %>
+          <div>Nested content here.</div>
+        <% end %>
+      <% end %>
+    ERB
+
+    output = render(src, scope)
+
+    expect(output.strip).to eq <<~TEXT.strip
+      true: <div>Some content here.</div>
+        true: <div>Nested content here.</div>
+    TEXT
+  end
+
   it "supports case expressions" do
     # Case expressions need this unconventional opening tag to work in ERB; see this 2009 gist for
     # more: https://gist.github.com/davidphasson/91613

--- a/spec/integration/template_engines/haml_spec.rb
+++ b/spec/integration/template_engines/haml_spec.rb
@@ -62,4 +62,26 @@ RSpec.describe "Template engines / haml" do
 
     expect(output.strip).to eq "true"
   end
+
+  it "marks nested captured blocks as HTML safe" do
+    scope = Class.new {
+      def html_safe_capture
+        captured = yield
+        safe = captured.html_safe?
+
+        "#{safe}: #{captured.strip}".then { |str| safe ? str.html_safe : str }
+      end
+    }.new
+
+    src = <<~HAML
+      = html_safe_capture do
+        %div Some content here.
+        = html_safe_capture do
+          %div Nested content here.
+    HAML
+
+    output = Hanami::View::HamlAdapter::Template.new { src }.render(scope)
+
+    expect(output.strip).to eq "true: <div>Some content here.</div>\ntrue: <div>Nested content here.</div>"
+  end
 end

--- a/spec/integration/template_engines/haml_spec.rb
+++ b/spec/integration/template_engines/haml_spec.rb
@@ -2,6 +2,7 @@
 
 require "hanami/view"
 require "hanami/view/context"
+require "hanami/view/haml/template"
 
 RSpec.describe "Template engines / haml" do
   let(:base_view) {
@@ -42,5 +43,23 @@ RSpec.describe "Template engines / haml" do
     end.new
 
     expect(view.().to_s.gsub(/\n\s*/m, "")).to eq "<wrapper>Yielded</wrapper>"
+  end
+
+  it "marks captured block content as HTML safe" do
+    scope = Class.new {
+      def html_safe_capture
+        yield.html_safe?
+      end
+    }.new
+
+    src = <<~HAML
+      = html_safe_capture do
+        %div Some content
+        %div goes here.
+    HAML
+
+    output = Hanami::View::HamlAdapter::Template.new { src }.render(scope)
+
+    expect(output.strip).to eq "true"
   end
 end

--- a/spec/integration/template_engines/slim_spec.rb
+++ b/spec/integration/template_engines/slim_spec.rb
@@ -3,6 +3,7 @@
 require "slim"
 require "hanami/view"
 require "hanami/view/context"
+require "hanami/view/slim/template"
 
 RSpec.describe "Template engines / slim" do
   let(:base_view) {
@@ -43,5 +44,23 @@ RSpec.describe "Template engines / slim" do
     end.new
 
     expect(view.().to_s).to eq "<wrapper>Yielded</wrapper>"
+  end
+
+  it "marks captured block content as HTML safe" do
+    scope = Class.new {
+      def html_safe_capture
+        yield.html_safe?
+      end
+    }.new
+
+    src = <<~SLIM
+      = html_safe_capture do
+        div Some content
+        div goes here.
+    SLIM
+
+    output = Hanami::View::SlimAdapter::Template.new { src }.render(scope)
+
+    expect(output.strip).to eq "true"
   end
 end

--- a/spec/integration/template_engines/slim_spec.rb
+++ b/spec/integration/template_engines/slim_spec.rb
@@ -63,4 +63,26 @@ RSpec.describe "Template engines / slim" do
 
     expect(output.strip).to eq "true"
   end
+
+  it "marks nested captured blocks as HTML safe" do
+    scope = Class.new {
+      def html_safe_capture
+        captured = yield
+        safe = captured.html_safe?
+
+        "#{safe}: #{captured.strip}".then { |str| safe ? str.html_safe : str }
+      end
+    }.new
+
+    src = <<~SLIM
+      = html_safe_capture do
+        div Some content here.
+        = html_safe_capture do
+          div Nested content here.
+    SLIM
+
+    output = Hanami::View::SlimAdapter::Template.new { src }.render(scope)
+
+    expect(output.strip).to eq "true: <div>Some content here.</div>true: <div>Nested content here.</div>"
+  end
 end


### PR DESCRIPTION
This is important for Part or Scope methods (including the helpers we’ll soon be shipping) that want to determine whether to escape strings captured from template blocks based on whether they are `.html_safe?`.

It's the primary job of templates to create HTML, so it makes sense for all template-captured blocks to be marked as HTML safe in the first place.