### PR TITLE
Build any part inheriting from Part

### DIFF
--- a/lib/hanami/view/part_builder.rb
+++ b/lib/hanami/view/part_builder.rb
@@ -87,7 +87,7 @@ module Hanami
             klass = namespace.const_get(name)
           end
 
-          if klass && klass < rendering.config.part_class
+          if klass && klass < Part
             klass
           else
             rendering.config.part_class


### PR DESCRIPTION
This rolls back one small change from 57d771c501d08c31fe1f3ff8579ee4d4f3567a9c (#227), which had an unwanted side effect: if a `part_class` was configured, then any custom parts _not_ inheriting from that `part_class` were no longer being used, even if they inherited from `Hanami::View::Part`.

This is not the outcome we want: any legitimate part should be able to be used, while still falling back to the configured `part_class` in the case of no matching class being found.