### PR TITLE
Remove `frozen_string_literal: true` comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 
 eval_gemfile "Gemfile.devtools"

--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # this file is managed by dry-rb/devtools project
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "bundler/gem_tasks"
 
 require "rspec/core/rake_task"

--- a/benchmarks/comparative/hanami.rb
+++ b/benchmarks/comparative/hanami.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/view"
 require "ostruct"
 

--- a/benchmarks/comparative/rails.rb
+++ b/benchmarks/comparative/rails.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "action_view"
 require "action_controller"
 require "ostruct"

--- a/benchmarks/comparative/tilt.rb
+++ b/benchmarks/comparative/tilt.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "tilt"
 require "ostruct"
 

--- a/benchmarks/comparative_benchmark.rb
+++ b/benchmarks/comparative_benchmark.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "benchmark/ips"
 require_relative "comparative/hanami"
 require_relative "comparative/rails"

--- a/benchmarks/view_benchmark.rb
+++ b/benchmarks/view_benchmark.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "benchmark/ips"
 require_relative "comparative/hanami"
 

--- a/benchmarks/view_profile.rb
+++ b/benchmarks/view_profile.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hotch"
 require_relative "comparative/hanami"
 

--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require "bundler/setup"
 require "hanami-view"
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require_relative "setup_helpers"
 
 Setup.execute "bundle"

--- a/bin/setup_helpers.rb
+++ b/bin/setup_helpers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "open3"
 
 module Setup

--- a/hanami-view.gemspec
+++ b/hanami-view.gemspec
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hanami/view/version'

--- a/lib/hanami-view.rb
+++ b/lib/hanami-view.rb
@@ -1,3 +1,1 @@
-# frozen_string_literal: true
-
 require "hanami/view"

--- a/lib/hanami/view.rb
+++ b/lib/hanami/view.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/configurable"
 require "dry/core/equalizer"
 require "dry/inflector"

--- a/lib/hanami/view/cache.rb
+++ b/lib/hanami/view/cache.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/core/cache"
 
 module Hanami

--- a/lib/hanami/view/context.rb
+++ b/lib/hanami/view/context.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class View
     # Provides a baseline environment across all the templates, parts and scopes

--- a/lib/hanami/view/decorated_attributes.rb
+++ b/lib/hanami/view/decorated_attributes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "set"
 
 module Hanami

--- a/lib/hanami/view/erb/engine.rb
+++ b/lib/hanami/view/erb/engine.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "temple"
 
 module Hanami

--- a/lib/hanami/view/erb/filters/block.rb
+++ b/lib/hanami/view/erb/filters/block.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class View
     module ERB

--- a/lib/hanami/view/erb/filters/trimming.rb
+++ b/lib/hanami/view/erb/filters/trimming.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Based on Temple::ERB::Trimming, also released under the MIT licence.
 #
 # Copyright (c) 2010-2023 Magnus Holm.

--- a/lib/hanami/view/erb/parser.rb
+++ b/lib/hanami/view/erb/parser.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Hanami::View::ERB is based on Temple::ERB::Parser, also released under the MIT licence.
 #
 # Copyright (c) 2010-2023 Magnus Holm.

--- a/lib/hanami/view/erb/template.rb
+++ b/lib/hanami/view/erb/template.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "temple"
 require_relative "engine"
 

--- a/lib/hanami/view/errors.rb
+++ b/lib/hanami/view/errors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class View
     # @since 2.0.0

--- a/lib/hanami/view/exposure.rb
+++ b/lib/hanami/view/exposure.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/core/equalizer"
 
 module Hanami

--- a/lib/hanami/view/exposures.rb
+++ b/lib/hanami/view/exposures.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "tsort"
 require "dry/core/equalizer"
 

--- a/lib/hanami/view/helpers/escape_helper.rb
+++ b/lib/hanami/view/helpers/escape_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "temple"
 require "uri"
 

--- a/lib/hanami/view/helpers/number_formatting_helper.rb
+++ b/lib/hanami/view/helpers/number_formatting_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class View
     module Helpers

--- a/lib/hanami/view/helpers/tag_helper.rb
+++ b/lib/hanami/view/helpers/tag_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Based on ActionView::Helpers::TagHelper, also released under the MIT licence.
 #
 # Copyright (c) David Heinemeier Hansson

--- a/lib/hanami/view/helpers/tag_helper/tag_builder.rb
+++ b/lib/hanami/view/helpers/tag_helper/tag_builder.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "json"
 require "set"
 

--- a/lib/hanami/view/html.rb
+++ b/lib/hanami/view/html.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class View
     module HTML

--- a/lib/hanami/view/html_safe_string_buffer.rb
+++ b/lib/hanami/view/html_safe_string_buffer.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "temple"
 
 if Temple::VERSION <= "0.10.0"

--- a/lib/hanami/view/part.rb
+++ b/lib/hanami/view/part.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/core/equalizer"
 
 module Hanami

--- a/lib/hanami/view/part_builder.rb
+++ b/lib/hanami/view/part_builder.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class View
     # Decorates exposure values with matching parts

--- a/lib/hanami/view/path.rb
+++ b/lib/hanami/view/path.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "pathname"
 
 module Hanami

--- a/lib/hanami/view/rendered.rb
+++ b/lib/hanami/view/rendered.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/core/equalizer"
 
 module Hanami

--- a/lib/hanami/view/renderer.rb
+++ b/lib/hanami/view/renderer.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "errors"
 
 module Hanami

--- a/lib/hanami/view/rendering.rb
+++ b/lib/hanami/view/rendering.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class View
     # @api private

--- a/lib/hanami/view/rendering_missing.rb
+++ b/lib/hanami/view/rendering_missing.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/inflector"
 require_relative "errors"
 

--- a/lib/hanami/view/scope.rb
+++ b/lib/hanami/view/scope.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/core/equalizer"
 require "dry/core/constants"
 

--- a/lib/hanami/view/scope_builder.rb
+++ b/lib/hanami/view/scope_builder.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class View
     # Builds scope objects via matching classes

--- a/lib/hanami/view/tilt.rb
+++ b/lib/hanami/view/tilt.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "tilt"
 
 module Hanami

--- a/lib/hanami/view/tilt/haml_adapter.rb
+++ b/lib/hanami/view/tilt/haml_adapter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "haml"
 
 module Hanami

--- a/lib/hanami/view/tilt/slim_adapter.rb
+++ b/lib/hanami/view/tilt/slim_adapter.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "slim"
 
 module Hanami

--- a/lib/hanami/view/version.rb
+++ b/lib/hanami/view/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class View
     # @api private

--- a/spec/integration/context_spec.rb
+++ b/spec/integration/context_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Context" do
   it "Provides decorated attributes for use in templates and parts" do
     module Test

--- a/spec/integration/erb/erb_spec.rb
+++ b/spec/integration/erb/erb_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "tilt/erubi"
 
 RSpec.describe Hanami::View::ERB::Template do

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "exposures" do
   let(:context) {
     Class.new(Hanami::View::Context) do

--- a/spec/integration/helpers_spec.rb
+++ b/spec/integration/helpers_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "helpers" do
   let(:dir) { make_tmp_directory }
 

--- a/spec/integration/part/decorated_attributes_spec.rb
+++ b/spec/integration/part/decorated_attributes_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "dry/core/inflector"
 
 RSpec.describe "Part / Decorated attributes" do

--- a/spec/integration/part_builder_spec.rb
+++ b/spec/integration/part_builder_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "part builder" do
   before do
     module Test

--- a/spec/integration/scope_builder_spec.rb
+++ b/spec/integration/scope_builder_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "scope builder" do
   describe "default scope builder" do
     it "defaults to creating instances of Hanami::View::Scope" do

--- a/spec/integration/scope_spec.rb
+++ b/spec/integration/scope_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Scopes" do
   let(:base_view) {
     Class.new(Hanami::View) do

--- a/spec/integration/template_engines/erb_spec.rb
+++ b/spec/integration/template_engines/erb_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Template engines / erb (Hanami::View::ERB)" do
   let(:base_view) {
     Class.new(Hanami::View) do

--- a/spec/integration/template_engines/haml_spec.rb
+++ b/spec/integration/template_engines/haml_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Template engines / haml" do
   let(:base_view) {
     Class.new(Hanami::View) do

--- a/spec/integration/template_engines/slim_spec.rb
+++ b/spec/integration/template_engines/slim_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Template engines / slim" do
   let(:base_view) {
     Class.new(Hanami::View) do

--- a/spec/integration/testing/testing_parts_spec.rb
+++ b/spec/integration/testing/testing_parts_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Testing / parts" do
   specify "Parts can be unit tested without name or rendering (for testing methods that don't require them)" do
     part_class = Class.new(Hanami::View::Part) do

--- a/spec/integration/view/errors_spec.rb
+++ b/spec/integration/view/errors_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "View / errors" do
   specify "Raising an error when paths are not configured" do
     view_class = Class.new(Hanami::View) do

--- a/spec/integration/view/exposures_spec.rb
+++ b/spec/integration/view/exposures_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "View / exposures" do
   specify "exposures have access to context" do
     view = Class.new(Hanami::View) do

--- a/spec/integration/view/locals_spec.rb
+++ b/spec/integration/view/locals_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "View / locals" do
   specify "locals are decorated with parts by default" do
     view = Class.new(Hanami::View) do

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "hanami-view" do
   let(:view_class) do
     Class.new(Hanami::View) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "support/coverage"
 
 begin

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # this file is managed by dry-rb/devtools
 
 if ENV["COVERAGE"] == "true"

--- a/spec/support/tmp_directory.rb
+++ b/spec/support/tmp_directory.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/devtools/integration/files"
 require "hanami/devtools/integration/with_tmp_directory"
 require "tmpdir"

--- a/spec/support/warnings.rb
+++ b/spec/support/warnings.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # this file is managed by dry-rb/devtools project
 
 require "warning"

--- a/spec/unit/context_helpers/content_helpers_spec.rb
+++ b/spec/unit/context_helpers/content_helpers_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::Context, "ContentHelpers" do
   let(:context) {
     Class.new(described_class) do

--- a/spec/unit/context_spec.rb
+++ b/spec/unit/context_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::Context do
   let(:rendering) {
     Class.new(Hanami::View) {

--- a/spec/unit/decorated_attributes_spec.rb
+++ b/spec/unit/decorated_attributes_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::DecoratedAttributes do
   subject(:decoratable) {
     Test::Decoratable = Struct.new(:attr_1, :attr_2, :_rendering) do

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::Exposure do
   subject(:exposure) { described_class.new(:hello, proc, object, **options) }
 

--- a/spec/unit/exposures_spec.rb
+++ b/spec/unit/exposures_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::Exposures do
   subject(:exposures) { described_class.new }
 

--- a/spec/unit/helpers/escape_helper/escape_html_spec.rb
+++ b/spec/unit/helpers/escape_helper/escape_html_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::Helpers::EscapeHelper, ".escape_html" do
   def escape_html(...)
     described_class.escape_html(...)

--- a/spec/unit/helpers/escape_helper/sanitize_url_spec.rb
+++ b/spec/unit/helpers/escape_helper/sanitize_url_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::Helpers::EscapeHelper, ".sanitize_url" do
   def sanitize_url(...)
     described_class.sanitize_url(...)

--- a/spec/unit/helpers/escape_helper_spec.rb
+++ b/spec/unit/helpers/escape_helper_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::Helpers::EscapeHelper do
   subject(:obj) {
     Class.new {

--- a/spec/unit/helpers/number_formatting_helper_spec.rb
+++ b/spec/unit/helpers/number_formatting_helper_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "bigdecimal"
 
 RSpec.describe Hanami::View::Helpers::NumberFormattingHelper, "#format_number" do

--- a/spec/unit/helpers/tag_helper_spec.rb
+++ b/spec/unit/helpers/tag_helper_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::Helpers::TagHelper do
   describe "inclusion" do
     subject(:obj) {

--- a/spec/unit/html_spec.rb
+++ b/spec/unit/html_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::HTML::SafeString do
   subject(:safe_string) { described_class.new(string) }
   let(:string) { "hello" }

--- a/spec/unit/part_builder_spec.rb
+++ b/spec/unit/part_builder_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::PartBuilder do
   subject(:part_builder) { rendering.part_builder }
 

--- a/spec/unit/part_spec.rb
+++ b/spec/unit/part_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec::Matchers.define :scope_including do |locals|
   match do |actual|
     locals == actual._locals

--- a/spec/unit/rendered_spec.rb
+++ b/spec/unit/rendered_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::Rendered do
   subject(:rendered) {
     described_class.new(

--- a/spec/unit/renderer_spec.rb
+++ b/spec/unit/renderer_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::Renderer do
   subject(:renderer) { Hanami::View::Renderer.new(view_class.config) }
 

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::View::Scope do
   let(:locals) { {} }
 

--- a/spec/unit/view_spec.rb
+++ b/spec/unit/view_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "tilt/erubi"
 
 RSpec.describe Hanami::View do


### PR DESCRIPTION
Since we've moved to requiring Ruby >= 3.0 we no longer need to have the
`#frozen_string_literal: true` magic comment as strings are now frozen
by default.