### PR TITLE
Allow layout to be passed in `View#call`

### DIFF
--- a/lib/hanami/view.rb
+++ b/lib/hanami/view.rb
@@ -530,7 +530,7 @@ module Hanami
       locals = locals(rendering, input)
       output = rendering.template(config.template, rendering.scope(config.scope, locals))
 
-      if !!layout
+      if layout
         begin
           output = rendering.template(
             self.class.layout_path(layout),

--- a/spec/fixtures/templates/layouts/alternate.html.slim
+++ b/spec/fixtures/templates/layouts/alternate.html.slim
@@ -1,0 +1,6 @@
+doctype html
+html
+  head
+    title == "Alternate layout #{title}"
+  body
+    = yield

--- a/spec/unit/view_spec.rb
+++ b/spec/unit/view_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe Hanami::View do
         "<!DOCTYPE html><html><head><title>Test</title></head><body><h1>User</h1><p>Jane</p></body></html>"
       )
     end
+
+    it "allows a different layout to be passed to call" do
+      expect(view.(context:, layout: "alternate").to_s).to eql(
+        "<!DOCTYPE html><html><head><title>Alternate layout Test</title></head><body><h1>User</h1><p>Jane</p></body></html>"
+      )
+    end
+
+    it "allows a nil layout to be passed to call" do
+      expect(view.(context:, layout: nil).to_s).to eql(
+        "<h1>User</h1><p>Jane</p>"
+      )
+    end
   end
 
   describe "layout rendering" do

--- a/spec/unit/view_spec.rb
+++ b/spec/unit/view_spec.rb
@@ -35,13 +35,13 @@ RSpec.describe Hanami::View do
     end
 
     it "allows a different layout to be passed to call" do
-      expect(view.(context:, layout: "alternate").to_s).to eql(
+      expect(view.(context: context, layout: "alternate").to_s).to eql(
         "<!DOCTYPE html><html><head><title>Alternate layout Test</title></head><body><h1>User</h1><p>Jane</p></body></html>"
       )
     end
 
     it "allows a nil layout to be passed to call" do
-      expect(view.(context:, layout: nil).to_s).to eql(
+      expect(view.(context: context, layout: nil).to_s).to eql(
         "<h1>User</h1><p>Jane</p>"
       )
     end


### PR DESCRIPTION
In order to be able to render a view but with a different layout to the
one that is expected, we need to allow the layout to be specified, or to
be removed by passing `nil` or `false`, in the `call` interface of the
`View` class.

With these changes, this now works from a `hanami-controller` action:

```ruby
response.render(view, layout: nil)
```

As does this:

```ruby
view.call(layout: nil)
```