### PR TITLE
Include methods from helper modules as public

### DIFF
--- a/lib/hanami/view/helpers/escape_helper.rb
+++ b/lib/hanami/view/helpers/escape_helper.rb
@@ -31,7 +31,7 @@ module Hanami
       # @api public
       # @since 2.0.0
       module EscapeHelper
-        module_function
+        extend self
 
         # Returns an escaped string that is safe to include in HTML.
         #

--- a/lib/hanami/view/helpers/number_formatting_helper.rb
+++ b/lib/hanami/view/helpers/number_formatting_helper.rb
@@ -28,7 +28,7 @@ module Hanami
       # @api public
       # @since 2.0.0
       module NumberFormattingHelper
-        module_function
+        extend self
 
         # Default delimiter
         #

--- a/lib/hanami/view/helpers/tag_helper.rb
+++ b/lib/hanami/view/helpers/tag_helper.rb
@@ -32,7 +32,7 @@ module Hanami
       # @api public
       # @since 2.0.0
       module TagHelper
-        module_function
+        extend self
 
         # Returns a tag builder for building HTML tag strings.
         #

--- a/spec/unit/helpers/escape_helper_spec.rb
+++ b/spec/unit/helpers/escape_helper_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe Hanami::View::Helpers::EscapeHelper do
     obj.instance_eval(&block)
   end
 
-  it "includes private helpers only" do
-    expect { obj.escape_html }.to raise_error(NoMethodError)
-  end
-
   # See escape_hepler/escape_html_spec.rb for complete tests
   describe "#escape_html" do
     it "escapes HTML" do

--- a/spec/unit/helpers/tag_helper_spec.rb
+++ b/spec/unit/helpers/tag_helper_spec.rb
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Hanami::View::Helpers::TagHelper do
-  describe "inclusion" do
-    subject(:obj) {
-      Class.new {
-        include Hanami::View::Helpers::TagHelper
-      }.new
-    }
-
-    it "includes private helpers only" do
-      expect { obj.tag }.to raise_error(NoMethodError)
-    end
-  end
-
   describe "#tag" do
     def tag(...)
       described_class.tag(...)


### PR DESCRIPTION
I previously used `module_function` to make helper modules provide access to their methods directly, while also making those methods private when included in another module.

This has turned out to be counterproductive, because we need these methods to be public for our work to create an intermediary `helpers` object that can be used inside view parts (see https://github.com/hanami/hanami/pull/1354).

Instead, switch to using `extend self` to achieve the same effect of direct access while still allowing the methods to remain public when the modules are included.