### PR TITLE
Require latest tilt

### DIFF
--- a/hanami-view.gemspec
+++ b/hanami-view.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-core", "~> 1.0"
   spec.add_runtime_dependency "dry-inflector", "~> 1.0", "< 2"
   spec.add_runtime_dependency "temple", "~> 0.10.0", ">= 0.10.2"
-  spec.add_runtime_dependency "tilt", "~> 2.0", ">= 2.0.6"
+  spec.add_runtime_dependency "tilt", "~> 2.3"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
We provided a fix to tilt (https://github.com/jeremyevans/tilt/pull/3) to address issues accessing `locals` in templates. Use the latest tilt to ensure users have this fix in their bundle.

Resolves #241.