### PR TITLE
Remove concurrent-ruby dependency from gemspec

### DIFF
--- a/hanami-view.gemspec
+++ b/hanami-view.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.0"
 
-  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_runtime_dependency "dry-configurable", "~> 1.0"
   spec.add_runtime_dependency "dry-core", "~> 1.0"
   spec.add_runtime_dependency "dry-inflector", "~> 1.0", "< 2"


### PR DESCRIPTION
This is no longer used within the gem.