### PR TITLE
Fix: Add support for rendering multiple scopes by passing string as names

### DIFF
--- a/lib/hanami/view/scope_builder.rb
+++ b/lib/hanami/view/scope_builder.rb
@@ -31,7 +31,7 @@ module Hanami
           elsif name.is_a?(Class)
             name
           else
-            View.cache.fetch_or_store(:scope_class, rendering.config) do
+            View.cache.fetch_or_store("scope_class: #{name}", rendering.config) do
               resolve_scope_class(name: name, rendering: rendering)
             end
           end
@@ -40,7 +40,7 @@ module Hanami
         def resolve_scope_class(name:, rendering:)
           name = rendering.inflector.camelize(name.to_s)
 
-          namespace = rendering.config.scope_namespace
+          namespace = rendering.config.scope_namespace || Object
 
           # Give autoloaders a chance to act
           begin

--- a/lib/hanami/view/scope_builder.rb
+++ b/lib/hanami/view/scope_builder.rb
@@ -40,7 +40,7 @@ module Hanami
         def resolve_scope_class(name:, rendering:)
           name = rendering.inflector.camelize(name.to_s)
 
-          namespace = rendering.config.scope_namespace || Object
+          namespace = rendering.config.scope_namespace
 
           # Give autoloaders a chance to act
           begin

--- a/lib/hanami/view/scope_builder.rb
+++ b/lib/hanami/view/scope_builder.rb
@@ -31,7 +31,7 @@ module Hanami
           elsif name.is_a?(Class)
             name
           else
-            View.cache.fetch_or_store("scope_class: #{name}", rendering.config) do
+            View.cache.fetch_or_store(name, rendering.config) do
               resolve_scope_class(name: name, rendering: rendering)
             end
           end

--- a/spec/integration/scope_builder_spec.rb
+++ b/spec/integration/scope_builder_spec.rb
@@ -27,5 +27,31 @@ RSpec.describe "scope builder" do
 
       expect(scope).to be_an_instance_of scope_class
     end
+
+    context 'when multiple scopes are rendered in the same view' do
+
+      let(:builder) { described_class.new }
+
+      it 'allows to build scopes with different classes' do
+        FirstScopeClass =  Class.new(Hanami::View::Scope)
+        SecondScopeClass =  Class.new(Hanami::View::Scope)
+
+        view = Class.new(Hanami::View) do
+          config.paths = SPEC_ROOT.join("__ignore__")
+          config.template = "__ignore__"
+
+          config.scope_class = FirstScopeClass
+        end.new
+
+        scope = view.rendering.scope({})
+        expect(scope).to be_an_instance_of FirstScopeClass
+
+        scope = view.rendering.scope('SecondScopeClass', {})
+        expect(scope).to be_an_instance_of SecondScopeClass
+
+        scope = view.rendering.scope('FirstScopeClass', {})
+        expect(scope).to be_an_instance_of FirstScopeClass
+      end
+    end
   end
 end

--- a/spec/integration/scope_builder_spec.rb
+++ b/spec/integration/scope_builder_spec.rb
@@ -28,26 +28,30 @@ RSpec.describe "scope builder" do
       expect(scope).to be_an_instance_of scope_class
     end
 
-    describe "multiple user-defined scopes" do
+    describe "named scopes" do
+      let(:namespace) { Module.new }
       let(:scope_one) { Class.new(Hanami::View::Scope) }
       let(:scope_two) { Class.new(Hanami::View::Scope) }
 
       before do
-        stub_const "ScopeOne", scope_one
-        stub_const "ScopeTwo", scope_two
+        stub_const "TestScopes", namespace
+        stub_const "TestScopes::ScopeOne", scope_one
+        stub_const "TestScopes::ScopeTwo", scope_two
       end
 
       it "creates instances of the scopes by name" do
-        view = Class.new(Hanami::View) do
+        view = Class.new(Hanami::View) {
+          config.scope_namespace = TestScopes
+
           config.paths = SPEC_ROOT.join("__ignore__")
           config.template = "__ignore__"
-        end.new
+        }.new
 
         scope = view.rendering.scope("scope_one", {})
-        expect(scope).to be_an_instance_of ScopeOne
+        expect(scope).to be_an_instance_of TestScopes::ScopeOne
 
         scope = view.rendering.scope("scope_two", {})
-        expect(scope).to be_an_instance_of ScopeTwo
+        expect(scope).to be_an_instance_of TestScopes::ScopeTwo
       end
     end
   end

--- a/spec/integration/scope_builder_spec.rb
+++ b/spec/integration/scope_builder_spec.rb
@@ -28,29 +28,26 @@ RSpec.describe "scope builder" do
       expect(scope).to be_an_instance_of scope_class
     end
 
-    context 'when multiple scopes are rendered in the same view' do
+    describe "multiple user-defined scopes" do
+      let(:scope_one) { Class.new(Hanami::View::Scope) }
+      let(:scope_two) { Class.new(Hanami::View::Scope) }
 
-      let(:builder) { described_class.new }
+      before do
+        stub_const "ScopeOne", scope_one
+        stub_const "ScopeTwo", scope_two
+      end
 
-      it 'allows to build scopes with different classes' do
-        FirstScopeClass =  Class.new(Hanami::View::Scope)
-        SecondScopeClass =  Class.new(Hanami::View::Scope)
-
+      it "creates instances of the scopes by name" do
         view = Class.new(Hanami::View) do
           config.paths = SPEC_ROOT.join("__ignore__")
           config.template = "__ignore__"
-
-          config.scope_class = FirstScopeClass
         end.new
 
-        scope = view.rendering.scope({})
-        expect(scope).to be_an_instance_of FirstScopeClass
+        scope = view.rendering.scope("scope_one", {})
+        expect(scope).to be_an_instance_of ScopeOne
 
-        scope = view.rendering.scope('SecondScopeClass', {})
-        expect(scope).to be_an_instance_of SecondScopeClass
-
-        scope = view.rendering.scope('FirstScopeClass', {})
-        expect(scope).to be_an_instance_of FirstScopeClass
+        scope = view.rendering.scope("scope_two", {})
+        expect(scope).to be_an_instance_of ScopeTwo
       end
     end
   end

--- a/spec/unit/scope_builder_spec.rb
+++ b/spec/unit/scope_builder_spec.rb
@@ -15,21 +15,23 @@ RSpec.describe Hanami::View::ScopeBuilder, "#call" do
   let(:namespace) { nil }
 
   describe "caching" do
+    let(:namespace) { TestScopes }
     let(:scope_one) { Class.new(Hanami::View::Scope) }
     let(:scope_two) { Class.new(Hanami::View::Scope) }
 
     before do
       Hanami::View::Cache.clear
 
-      stub_const "ScopeOne", scope_one
-      stub_const "ScopeTwo", scope_two
+      stub_const "TestScopes", Module.new
+      stub_const "TestScopes::ScopeOne", scope_one
+      stub_const "TestScopes::ScopeTwo", scope_two
     end
 
     it "caches each resolved scope" do
       scope_builder.call("scope_one", locals: {}, rendering: rendering)
       scope_builder.call("scope_two", locals: {}, rendering: rendering)
 
-      expect(Hanami::View::Cache.cache.values).to eq [ScopeOne, ScopeTwo]
+      expect(Hanami::View::Cache.cache.values).to eq [TestScopes::ScopeOne, TestScopes::ScopeTwo]
     end
   end
 end

--- a/spec/unit/scope_builder_spec.rb
+++ b/spec/unit/scope_builder_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::View::ScopeBuilder, "#call" do
+  subject(:scope_builder) { rendering.scope_builder }
+
+  let(:rendering) { view.rendering(format: :html) }
+  let(:view) {
+    scope_namespace = namespace
+    Class.new(Hanami::View) {
+      config.paths = FIXTURES_PATH
+      config.template = "_"
+      config.scope_namespace = scope_namespace
+    }.new
+  }
+  let(:namespace) { nil }
+
+  describe "caching" do
+    let(:scope_one) { Class.new(Hanami::View::Scope) }
+    let(:scope_two) { Class.new(Hanami::View::Scope) }
+
+    before do
+      Hanami::View::Cache.clear
+
+      stub_const "ScopeOne", scope_one
+      stub_const "ScopeTwo", scope_two
+    end
+
+    it "caches each resolved scope" do
+      scope_builder.call("scope_one", locals: {}, rendering: rendering)
+      scope_builder.call("scope_two", locals: {}, rendering: rendering)
+
+      expect(Hanami::View::Cache.cache.values).to eq [ScopeOne, ScopeTwo]
+    end
+  end
+end


### PR DESCRIPTION
## Background

Resolves: #252 

### Bug 1. 

When scope name is passed as string (either scope class name, or the path to the file), the name resolving goes through the `cache`, with a hardcoded key `scope_class`, not allowing mutliple scopes to be stored and fetched.

### Bug 2.

If namespace is not defined (nil), `const_defined?` is called on `nil`, causing Undefined method error to be risen.

## Design

- Add spec covering both issues detected.
- Change the hardcoded cache key to the one taking passed name into the consideration
- Add support to `nil` namespace, falling back to the Object, so we can use `const_get` and `const_defined?` methods.
