### PR TITLE
Exclude tilt extensions from autoloading

### DIFF
--- a/lib/hanami/view.rb
+++ b/lib/hanami/view.rb
@@ -32,6 +32,7 @@ module Hanami
           "#{root}/hanami-view.rb",
           "#{root}/hanami/view/version.rb",
           "#{root}/hanami/view/errors.rb",
+          "#{root}/hanami/view/tilt/*.rb"
         )
         loader.inflector = Zeitwerk::GemInflector.new("#{root}/hanami-view.rb")
         loader.inflector.inflect(

--- a/spec/integration/template_engines/haml_spec.rb
+++ b/spec/integration/template_engines/haml_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "hanami/view/tilt/haml_adapter"
+
 RSpec.describe "Template engines / haml" do
   let(:base_view) {
     Class.new(Hanami::View) do

--- a/spec/integration/template_engines/haml_spec.rb
+++ b/spec/integration/template_engines/haml_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "hanami/view/tilt"
 require "hanami/view/tilt/haml_adapter"
 
 RSpec.describe "Template engines / haml" do

--- a/spec/integration/template_engines/slim_spec.rb
+++ b/spec/integration/template_engines/slim_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "hanami/view/tilt/slim_adapter"
+
 RSpec.describe "Template engines / slim" do
   let(:base_view) {
     Class.new(Hanami::View) do

--- a/spec/integration/template_engines/slim_spec.rb
+++ b/spec/integration/template_engines/slim_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "hanami/view/tilt"
 require "hanami/view/tilt/slim_adapter"
 
 RSpec.describe "Template engines / slim" do


### PR DESCRIPTION
These are loaded by tilt, and excluding them from autoloading ensures we avoid errors when zeitwerk:check is run.

See [this forum topic](https://discourse.hanamirb.org/t/rails-app-with-hanami-fails-on-hanami-dependency-i-didnt-want-to-add/1126) for more.