### PR TITLE
Use non-deprecated URI parser in escape helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ View layer for Hanami
 
 ## v2.3.0 - 2025-11-12
 
+### Fixed
+
+- Avoid warnings (from deprecated `URI::RFC3986_PARSER.extract`) in escape helper. (@timriley in #267)
+
 ## v2.3.0.beta2 - 2025-10-17
 
 ### Changed

--- a/lib/hanami/view/helpers/escape_helper.rb
+++ b/lib/hanami/view/helpers/escape_helper.rb
@@ -120,11 +120,18 @@ module Hanami
         def sanitize_url(input, permitted_schemes = PERMITTED_URL_SCHEMES)
           return input if input.html_safe?
 
-          URI::DEFAULT_PARSER.extract(
+          URI_PARSER.extract(
             URI.decode_www_form_component(input.to_s),
             permitted_schemes
           ).first.to_s.html_safe
         end
+
+        # Use the RFC2396_PARSER if available. Modern Rubies should have RFC2396_PARSER available.
+        # Otherwise, fall back to the DEFAULT_PARSER (which may still raise deprecation warnings).
+        #
+        # @api private
+        URI_PARSER = URI.const_defined?(:RFC2396_PARSER) ? URI::RFC2396_PARSER : URI::DEFAULT_PARSER
+        private_constant :URI_PARSER
 
         # @api private
         # @since 2.1.0


### PR DESCRIPTION
Fix #256