### PR TITLE
Default to undecorated exposures

### DIFF
--- a/lib/hanami/view.rb
+++ b/lib/hanami/view.rb
@@ -235,6 +235,23 @@ module Hanami
     # @!scope class
     setting :inflector, default: Dry::Inflector.new
 
+    # @overload config.decorate_exposures=(value)
+    #   Controls whether exposures are decorated by default.
+    #
+    #   When set to `true`, all exposures will be decorated with matching Parts unless explicitly
+    #   marked with `decorate: false`.
+    #
+    #   When set to `false` (the default), exposures will not be decorated unless explicitly marked
+    #   with `decorate: true`, or declared with `decorate`.
+    #
+    #   Defaults to `false`.
+    #
+    #   @param value [Boolean] whether to decorate exposures by default
+    #   @api public
+    #   @since x.x.x
+    # @!scope class
+    setting :decorate_exposures, default: false
+
     # @overload config.renderer_options=(options)
     #   A hash of options to pass to the template engine. Template engines are
     #   provided by Tilt; see Tilt's documentation for what options your
@@ -288,13 +305,13 @@ module Hanami
     #   @param options [Hash] the exposure's options
     #   @option options [Boolean] :layout expose this value to the layout (defaults to false)
     #   @option options [Boolean] :decorate decorate this value in a matching Part (defaults to
-    #     true)
+    #     false, or the value of `config.decorate_exposures`)
     #   @option options [Symbol, Class] :as an alternative name or class to use when finding a
     #     matching Part
 
     # @overload expose(name, **options, &block)
     #   Define a value to be passed to the template. The return value of the
-    #   block will be decorated by a matching Part and passed to the template.
+    #   block will be passed to the template.
     #
     #   The block will be evaluated with the view instance as its `self`. The
     #   block's parameters will determine what it is given:
@@ -329,8 +346,8 @@ module Hanami
     #
     # @overload expose(name, **options)
     #   Define a value to be passed to the template, provided by an instance
-    #   method matching the name. The method's return value will be decorated by
-    #   a matching Part and passed to the template.
+    #   method matching the name. The method's return value will be passed to
+    #   the template.
     #
     #   The method's parameters will determine what it is given:
     #
@@ -369,8 +386,8 @@ module Hanami
     #
     # @overload expose(name, **options)
     #   Define a single value to pass through from the input data (when there is
-    #   no instance method matching the `name`). This value will be decorated by
-    #   a matching Part and passed to the template.
+    #   no instance method matching the `name`). This value will be passed to
+    #   the template.
     #
     #   @param name [Symbol] name for the exposure
     #   @macro exposure_options
@@ -380,7 +397,7 @@ module Hanami
     # @overload expose(*names, **options)
     #   Define multiple values to pass through from the input data (when there
     #   is no instance methods matching their names). These values will be
-    #   decorated by matching Parts and passed through to the template.
+    #   passed through to the template.
     #
     #   The provided options will be applied to all the exposures.
     #
@@ -409,6 +426,18 @@ module Hanami
     # @since 2.1.0
     def self.private_expose(*names, **options, &block)
       expose(*names, **options, private: true, &block)
+    end
+
+    # Defines an exposure that will be decorated with a matching Part.
+    #
+    # This is a shorthand for `expose(..., decorate: true)`.
+    #
+    # @see expose
+    #
+    # @api public
+    # @since 2.1.0
+    def self.decorate(*names, **options, &block)
+      expose(*names, **options, decorate: true, &block)
     end
 
     # Returns the defined exposures. These are unbound, since bound exposures
@@ -597,7 +626,7 @@ module Hanami
 
     def locals(rendering, input)
       exposures.(context: rendering.context, **input) do |value, exposure|
-        if exposure.decorate? && value
+        if exposure.decorate?(default: config.decorate_exposures) && value
           rendering.part(exposure.name, value, as: exposure.options[:as])
         else
           value

--- a/lib/hanami/view/exposure.rb
+++ b/lib/hanami/view/exposure.rb
@@ -85,8 +85,8 @@ module Hanami
 
       # @api private
       # @since 2.1.0
-      def decorate?
-        options.fetch(:decorate, true)
+      def decorate?(default: false)
+        options.fetch(:decorate, default)
       end
 
       # @api private

--- a/spec/integration/context_spec.rb
+++ b/spec/integration/context_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Context" do
       config.template = "decorated_attributes"
       config.part_namespace = Test::Parts
 
-      expose :user
+      expose :user, decorate: true
     end.new
 
     context = Test::Context.new(assets: Test::Assets.new)

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -185,13 +185,13 @@ RSpec.describe "exposures" do
       config.template = "users_with_count"
       config.default_format = :html
 
-      expose :users, as: Test::UserPart
+      expose :users, as: Test::UserPart, decorate: true
 
       expose :users_count do |users|
         "#{users.length} users"
       end
 
-      expose :article do |users|
+      expose :article, decorate: true do |users|
         "Great article from #{users.first.display_name}"
       end
     end.new

--- a/spec/integration/helpers_spec.rb
+++ b/spec/integration/helpers_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "helpers" do
         config.paths = dir
         config.template = "template"
 
-        expose :city, as: part_class
+        expose :city, as: part_class, decorate: true
       }.new
     }
 

--- a/spec/integration/part_builder_spec.rb
+++ b/spec/integration/part_builder_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe "part builder" do
         config.template = "decorated_parts"
         config.part_namespace = Test
 
-        expose :customs
-        expose :custom
+        expose :customs, decorate: true
+        expose :custom, decorate: true
         expose :ordinary
       end.new
 
@@ -69,8 +69,8 @@ RSpec.describe "part builder" do
         config.layout = nil
         config.template = "decorated_parts"
 
-        expose :customs, as: Test::CustomPart
-        expose :custom, as: Test::CustomPart
+        expose :customs, as: Test::CustomPart, decorate: true
+        expose :custom, as: Test::CustomPart, decorate: true
         expose :ordinary
       end.new
 
@@ -85,8 +85,8 @@ RSpec.describe "part builder" do
         config.layout = nil
         config.template = "decorated_parts"
 
-        expose :customs, as: [Test::CustomArrayPart, Test::CustomPart]
-        expose :custom, as: Test::CustomPart
+        expose :customs, as: [Test::CustomArrayPart, Test::CustomPart], decorate: true
+        expose :custom, as: Test::CustomPart, decorate: true
         expose :ordinary
       end.new
 
@@ -112,7 +112,8 @@ RSpec.describe "part builder" do
         config.layout = nil
         config.template = "decorated_parts"
 
-        expose :customs, :custom, :ordinary
+        expose :customs, :custom, decorate: true
+        expose :ordinary
       end.new
 
       expect(view.(customs: ["many things"], custom: "custom thing", ordinary: "ordinary thing").to_s).to eql(

--- a/spec/integration/scope_spec.rb
+++ b/spec/integration/scope_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe "Scopes" do
       config.scope_namespace = Test::Scopes
       config.template = "scope_from_part"
 
-      expose :message
+      expose :message, decorate: true
     end.new
 
     expect(view.(message: {text: "Hello from a part"}).to_s).to eq "Greeting: Hello from a part!"

--- a/spec/integration/view/exposures_spec.rb
+++ b/spec/integration/view/exposures_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "View / exposures" do
       config.paths = SPEC_ROOT.join("fixtures/templates")
       config.template = "greeting"
 
-      expose :greeting do |greeting:, context:|
+      expose :greeting, decorate: true do |greeting:, context:|
         "#{greeting}, #{context.name}"
       end
     end.new

--- a/spec/integration/view/locals_spec.rb
+++ b/spec/integration/view/locals_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "View / locals" do
-  specify "locals are decorated with parts by default" do
+  specify "locals are not decorated by default" do
     view = Class.new(Hanami::View) do
       config.paths = SPEC_ROOT.join("fixtures/templates")
       config.template = "greeting"
@@ -11,13 +11,106 @@ RSpec.describe "View / locals" do
 
     local = view.(greeting: "Hello").locals[:greeting]
 
-    expect(local).to be_a(Hanami::View::Part)
+    expect(local).to eq "Hello"
   end
 
-  specify "locals are not decorated if their exposure is marked as `decorate: false`" do
+  specify "locals are decorated if their exposure is marked as `decorate: true`" do
     view = Class.new(Hanami::View) do
       config.paths = SPEC_ROOT.join("fixtures/templates")
       config.template = "greeting"
+
+      expose :greeting, decorate: true
+    end.new
+
+    local = view.(greeting: "Hello").locals[:greeting]
+
+    expect(local).to be_a(Hanami::View::Part)
+  end
+
+  specify "locals can be decorated using the `decorate` method" do
+    view = Class.new(Hanami::View) do
+      config.paths = SPEC_ROOT.join("fixtures/templates")
+      config.template = "greeting"
+
+      decorate :greeting
+    end.new
+
+    local = view.(greeting: "Hello").locals[:greeting]
+
+    expect(local).to be_a(Hanami::View::Part)
+  end
+
+  specify "`decorate` method works with blocks" do
+    view = Class.new(Hanami::View) do
+      config.paths = SPEC_ROOT.join("fixtures/templates")
+      config.template = "greeting"
+
+      decorate :greeting do |greeting:|
+        greeting.upcase
+      end
+    end.new
+
+    local = view.(greeting: "Hello").locals[:greeting]
+
+    expect(local).to be_a(Hanami::View::Part)
+    expect(local.value).to eq "HELLO"
+  end
+
+  specify "`decorate` method works with multiple exposures" do
+    view = Class.new(Hanami::View) do
+      config.paths = SPEC_ROOT.join("fixtures/templates")
+      config.template = "greeting"
+
+      decorate :greeting, :message
+    end.new
+
+    result = view.(greeting: "Hello", message: "World")
+
+    expect(result.locals[:greeting]).to be_a(Hanami::View::Part)
+    expect(result.locals[:message]).to be_a(Hanami::View::Part)
+  end
+
+  specify "`decorate` method supports :as option" do
+    module Test
+      class CustomPart < Hanami::View::Part
+        def custom_method
+          "Custom: #{value}"
+        end
+      end
+    end
+
+    view = Class.new(Hanami::View) do
+      config.paths = SPEC_ROOT.join("fixtures/templates")
+      config.template = "greeting"
+
+      decorate :greeting, as: Test::CustomPart
+    end.new
+
+    local = view.(greeting: "Hello").locals[:greeting]
+
+    expect(local).to be_a(Test::CustomPart)
+    expect(local.custom_method).to eq "Custom: Hello"
+  end
+
+  specify "locals are decorated by default when config.decorate_exposures is true" do
+    view = Class.new(Hanami::View) do
+      config.paths = SPEC_ROOT.join("fixtures/templates")
+      config.template = "greeting"
+      config.decorate_exposures = true
+
+      expose :greeting
+    end.new
+
+    local = view.(greeting: "Hello").locals[:greeting]
+
+    expect(local).to be_a(Hanami::View::Part)
+  end
+
+  specify "locals are not decorated when config.decorate_exposures is true but exposure has decorate: false" do
+    view = Class.new(Hanami::View) do
+      config.paths = SPEC_ROOT.join("fixtures/templates")
+      config.template = "greeting"
+      config.decorate_exposures = true
 
       expose :greeting, decorate: false
     end.new

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "hanami-view" do
       config.template = "users"
       config.default_format = :html
 
-      expose :users do
+      expose :users, decorate: true do
         [
           {name: "Jane", email: "jane@doe.org"},
           {name: "Joe", email: "joe@doe.org"}

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -37,11 +37,15 @@ RSpec.describe Hanami::View::Exposure do
     end
 
     describe "#decorate?" do
-      it "is true by default" do
-        expect(exposure.decorate?).to eq true
+      it "is false by default" do
+        expect(exposure.decorate?).to eq false
       end
 
-      it "can be set on initialization" do
+      it "can be set to true on initialization" do
+        expect(described_class.new(:hello, decorate: true).decorate?).to eq true
+      end
+
+      it "can be set to false on initialization" do
         expect(described_class.new(:hello, decorate: false).decorate?).to eq false
       end
     end


### PR DESCRIPTION
Change `expose` so that it no longer decorates by default, and ask the user to indicate which exposures should be decorated:

- `expose :foo` is now the equivalent of `expose :foo, decorate: false`
- `decorate :foo` is a new class-level method, a convenience that equates to `expose :foo, decorate: true`

This addresses a couple of downsides to our previous behaviour of decorating every exposure by default:

- Users may be surprised to find their values wrapped in parts
- There is a performance impact of wrapping every object in a part; this may be felt when exposing large collections from the view

To restore decorated exposures by default, set `config.decorate_exposures = true` in your view class.