### PR TITLE
Allow eager loading when haml and slim gems aren't installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 - Cache the view's resolved configuration as a frozen `Data` snapshot (via dry-configurable's `#to_data`) at initialization, avoiding repeated config lookups on the rendering hot path for improved memory usage and speed. (@cllns in #276)
 - Require Ruby 3.3 or newer.
 
+### Fixed
+
+- Allow the gem to be eager loaded by Zeitwerk when the optional haml and slim gems are not installed. (@timriley in #279)
+- Use our own Haml template engine even when the haml gem is required before hanami-view. (@timriley in #279)
+
 [3.0.0]: https://github.com/hanami/view/compare/v2.3.1...v3.0.0
 
 ## [3.0.0.rc1] - 2026-06-16

--- a/lib/hanami/view.rb
+++ b/lib/hanami/view.rb
@@ -30,7 +30,12 @@ module Hanami
         loader.ignore(
           "#{root}/hanami-view.rb",
           "#{root}/hanami/view/version.rb",
-          "#{root}/hanami/view/errors.rb"
+          "#{root}/hanami/view/errors.rb",
+          # These adapters require the optional "haml" and "slim" gems. They are loaded lazily by
+          # Tilt (see Hanami::View::Tilt) only when their respective template engines are used;
+          # ignore them here to allow eager loading without those gems installed.
+          "#{root}/hanami/view/tilt/haml_adapter.rb",
+          "#{root}/hanami/view/tilt/slim_adapter.rb"
         )
         loader.inflector = Zeitwerk::GemInflector.new("#{root}/hanami-view.rb")
         loader.inflector.inflect(

--- a/lib/hanami/view/tilt.rb
+++ b/lib/hanami/view/tilt.rb
@@ -10,14 +10,24 @@ module Hanami
       # @api private
       # @since 2.1.0
       Mapping = ::Tilt.default_mapping.dup.tap { |mapping|
-        # If "slim" has been required before "hanami/view", unregister Slim's non-lazy registered
-        # template, so our own template adapter (using register_lazy below) can take precedence.
-        mapping.unregister "slim"
+        # Unregister any existing mappings for the extensions we provide our own engines for.
+        #
+        # Tilt preferences non-lazy registrations over lazy ones (see `Tilt::Mapping#lookup`). So if
+        # "haml" or "slim" has been required before this mapping is built (each of which registers
+        # its own non-lazy mapping with Tilt), our own lazy-registered adapters below would be
+        # shadowed and never picked up, and templates would render without our specific required
+        # behavior.
+        #
+        # Unregistering first ensures our engines are always used, regardless of load order.
+        mapping.unregister "erb", "rhtml", "haml", "slim"
 
         # Register our own ERB template.
         mapping.register_lazy "Hanami::View::ERB::Template", "hanami/view/erb/template", "erb", "rhtml"
 
-        # Register ERB templates for Haml and Slim that set the `use_html_safe: true` option.
+        # Register templates for Haml and Slim that set the `use_html_safe: true` option.
+        #
+        # We register these lazily so that the optional "haml" and "slim" gems only need to be
+        # installed when their templates are actually used.
         #
         # Our template namespaces below have the "Adapter" suffix to work around a bug in Tilt's
         # `Mapping#const_defined?`, which (if slim was already required) would receive

--- a/spec/integration/template_engines/haml_spec.rb
+++ b/spec/integration/template_engines/haml_spec.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# This adapter is ignored by our Zeitwerk loader, since it requires the optional "haml" gem. Load it
+# explicitly for these tests.
+require "hanami/view/tilt/haml_adapter"
+
 RSpec.describe "Template engines / haml" do
   let(:base_view) {
     Class.new(Hanami::View) do

--- a/spec/integration/template_engines/slim_spec.rb
+++ b/spec/integration/template_engines/slim_spec.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# This adapter is ignored by our Zeitwerk loader, since it requires the optional "slim" gem. Load it
+# explicitly for these tests.
+require "hanami/view/tilt/slim_adapter"
+
 RSpec.describe "Template engines / slim" do
   let(:base_view) {
     Class.new(Hanami::View) do

--- a/spec/unit/eager_load_spec.rb
+++ b/spec/unit/eager_load_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::View, "eager loading" do
+  it "can be eager loaded even when the optional haml and slim gems are unavailable" do
+    # Simulate the haml and slim gems not being installed. The adapters that require them are loaded
+    # lazily by Tilt (see `Hanami::View::Tilt`) only when their template engines are used, so eager
+    # loading must not attempt to load them.
+    allow_any_instance_of(Object).to receive(:require).and_wrap_original do |original, name, *args|
+      if %w[haml slim].include?(name)
+        raise LoadError, "cannot load such file -- #{name}"
+      end
+
+      original.call(name, *args)
+    end
+
+    expect { Hanami::View.gem_loader.eager_load(force: true) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Zeitwerk eager loading would try to load our haml and slim Tilt adapters, which in turn require the optional "haml" and "slim" gems at the top level. This broke eager loading whenever those gems weren't installed. The adapters are already loaded lazily by Tilt only when their template engines are used, so ignore them in the gem loader.

While fixing this, make our Tilt mapping setup more robust. Tilt gives non-lazy registered templates precedence over lazy ones, so if "haml" or "slim" was required before hanami-view, their own template engines would be used in preference to ours (and we'd end up missing our required rendering behavior). To address this, unregister from our Tilt mapping _every_ extension we provide an extension for, before lazily registering our own. This ensures our template engines are always used regardless of load order. We had previously done this for Slim only, now we do it for all our template types.

Fixes #278