### PR TITLE
Report calling template as “current” inside yielded blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Fixed
 
+- Report the calling template as the current template name inside blocks passed to `render`, instead of the partial the block is yielded into. (@timriley in #281)
+
 ### Security
 
 [Unreleased]: https://github.com/hanami/view/compare/v3.0.0...HEAD

--- a/lib/hanami/view/renderer.rb
+++ b/lib/hanami/view/renderer.rb
@@ -48,6 +48,7 @@ module Hanami
 
       def template(name, format, scope, &block)
         old_prefixes = @prefixes.dup
+        old_template_names = @current_template_names
 
         result = lookup(name, format)
         raise TemplateNotFoundError.new(name, format, config_data.paths) unless result
@@ -56,12 +57,12 @@ module Hanami
 
         new_prefix = File.dirname(name)
         @prefixes << new_prefix unless @prefixes.include?(new_prefix)
-        @current_template_names << resolve_template_name(relative_path)
+        @current_template_names = old_template_names + [resolve_template_name(relative_path)]
 
-        render(template_path, scope, &block)
+        render(template_path, scope, &yielded_block(block, old_template_names))
       ensure
         @prefixes = old_prefixes
-        @current_template_names.pop if result
+        @current_template_names = old_template_names
       end
 
       def partial(name, format, scope, &block)
@@ -103,6 +104,28 @@ module Hanami
               end
             end
             nil
+          end
+        }
+      end
+
+      # Wraps a block yielded into a template so that, while it runs, `#current_template_name`
+      # reports the template that _wrote_ the block, not the one yielding to it.
+      #
+      # A block passed to `render` is written inside the calling template, so its contents belong to
+      # that template even though they're evaluated during the rendering of another.
+      #
+      # @return [Proc, nil]
+      def yielded_block(block, caller_template_names)
+        return nil unless block
+
+        proc { |*args|
+          yielding_template_names = @current_template_names
+          @current_template_names = caller_template_names
+
+          begin
+            block.call(*args)
+          ensure
+            @current_template_names = yielding_template_names
           end
         }
       end

--- a/spec/integration/template_rendering/current_template_name_spec.rb
+++ b/spec/integration/template_rendering/current_template_name_spec.rb
@@ -112,6 +112,34 @@ RSpec.describe "Template rendering / Current template name" do
     ])
   end
 
+  it "reports the calling template's name inside a block yielded to a partial" do
+    with_directory(dir) do
+      write "show.html.erb", "<%= render('wrapper') do %>[<%= template_name %>]<% end %>"
+      write "_wrapper.html.erb", "(<%= template_name %>|<%= yield %>)"
+    end
+
+    expect(build_view(template: "show").call(context:).to_s).to eq "(_wrapper|[show])"
+  end
+
+  it "reports the calling template's name inside a block yielded through nested partials" do
+    with_directory(dir) do
+      write "show.html.erb", "<%= render('outer') %>"
+      write "_outer.html.erb", "<%= render('inner') do %>[<%= template_name %>]<% end %>"
+      write "_inner.html.erb", "(<%= template_name %>|<%= yield %>)"
+    end
+
+    expect(build_view(template: "show").call(context:).to_s).to eq "(_inner|[_outer])"
+  end
+
+  it "restores the yielding template's name after a yielded block returns" do
+    with_directory(dir) do
+      write "show.html.erb", "<%= render('wrapper') do %>B:<%= template_name %><% end %>"
+      write "_wrapper.html.erb", "1:<%= template_name %>|<%= yield %>|2:<%= template_name %>"
+    end
+
+    expect(build_view(template: "show").call(context:).to_s).to eq "1:_wrapper|B:show|2:_wrapper"
+  end
+
   it "restores the outer template name after a partial returns" do
     with_directory(dir) do
       write "show.html.erb", <<~ERB


### PR DESCRIPTION
`Renderer#current_template_name` tracks the _render_ stack, so a block passed to `render` would report the name of the partial it was yielded *into*, not the template that wrote it. Content in the block is written in the calling template, so that's the name it should see as the current template.

This issue was surfaced through Hanami's i18n helper, where a relative translation key in a yielded block expanded against the wrong template:

```
<%# shared/popovers/_command.html.erb %>
<%= render("shared/popovers/default") do %>
  <%= t(".test") %>
<% end %>
```

`t(".test")` looked up `shared.popovers._default.test` instead of `shared.popovers._command.test`.

To fix this, trap the yielded block so the template name stack is restored to the caller's for the duration of the block, then swap it back. Tracking the stack by replacement rather than in-place mutation also lets the `ensure` restore unconditionally, dropping the `pop if result` guard.

Fixes https://github.com/hanami/hanami/issues/1618