### PR TITLE
Fix lookup of bare-named partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 ### Fixed
 
 - Report the calling template as the current template name inside blocks passed to `render`, instead of the partial the block is yielded into. (@timriley in #281)
+- Look up bare-named partials in the directory containing the template that renders them, instead of a same-named directory at the root. (@timriley in #282)
+
+    Previously, a partial rendered via a relative path (e.g. `render("shared/fields")` from `posts/show`) would look for its own bare-named partials under `shared/` at the root, rather than `posts/shared/`.
 
 ### Security
 

--- a/lib/hanami/view/renderer.rb
+++ b/lib/hanami/view/renderer.rb
@@ -16,7 +16,7 @@ module Hanami
     #   rendered, its parent directory (e.g. `"users"` for `"users/index"`) is pushed onto the stack
     #   so that a partial referenced by its bare name (e.g. `render("form")` from inside
     #   `users/index.html.erb`) can be found alongside the template that renders it. The stack is
-    #    snapshot-and-restored around each render via `ensure`.
+    #   snapshot-and-restored around each render via `ensure`.
     #
     # `#lookup` tries every combination of a path and a prefix, joining each pair with the
     # requested name to find a matching file. `paths` are checked in configured order; an earlier
@@ -55,7 +55,7 @@ module Hanami
 
         template_path, relative_path = result
 
-        new_prefix = File.dirname(name)
+        new_prefix = File.dirname(relative_path)
         @prefixes << new_prefix unless @prefixes.include?(new_prefix)
         @current_template_names = old_template_names + [resolve_template_name(relative_path)]
 

--- a/spec/integration/template_rendering/partial_lookup_spec.rb
+++ b/spec/integration/template_rendering/partial_lookup_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe "Template rendering / Partial lookup" do
+  let(:dir) { make_tmp_directory }
+
+  def build_view(template:, layout: false)
+    dir = self.dir
+    Class.new(Hanami::View) {
+      config.paths = dir
+      config.template = template
+      config.layout = layout
+    }.new
+  end
+
+  def write_template(*segments, content)
+    path = File.join(dir, *segments)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+
+  it "finds a bare-named partial alongside the template rendering it" do
+    write_template("users", "index.html.erb", "<%= render('form') %>")
+    write_template("users", "_form.html.erb", "[<%= template_name %>]")
+
+    expect(build_view(template: "users/index").call.to_s).to eq "[users/_form]"
+  end
+
+  it "finds a bare-named partial alongside the partial rendering it, at any depth" do
+    write_template("devices", "show.html.erb", "<%= render('shared/fields') %>")
+    write_template("devices", "shared", "_fields.html.erb", "<%= render('popovers/all') %>")
+    write_template("devices", "shared", "popovers", "_all.html.erb", "<%= render('command') %>")
+    write_template("devices", "shared", "popovers", "_command.html.erb", "[<%= template_name %>]")
+
+    expect(build_view(template: "devices/show").call.to_s)
+      .to eq "[devices/shared/popovers/_command]"
+  end
+
+  it "does not escape into a same-named directory at the root" do
+    write_template("devices", "show.html.erb", "<%= render('shared/fields') %>")
+    write_template("devices", "shared", "_fields.html.erb", "<%= render('popovers/all') %>")
+    write_template("devices", "shared", "popovers", "_all.html.erb", "nested[<%= template_name %>]")
+    # An unrelated top-level `shared/` tree, which must not be reached from `devices/shared/`.
+    write_template("shared", "popovers", "_all.html.erb", "root[<%= template_name %>]")
+
+    expect(build_view(template: "devices/show").call.to_s)
+      .to eq "nested[devices/shared/popovers/_all]"
+  end
+
+  it "still resolves a partial named by its full path from the root" do
+    write_template("devices", "show.html.erb", "<%= render('shared/popovers/all') %>")
+    write_template("shared", "popovers", "_all.html.erb", "[<%= template_name %>]")
+
+    expect(build_view(template: "devices/show").call.to_s).to eq "[shared/popovers/_all]"
+  end
+
+  it "restores the prefix stack after a nested render returns" do
+    write_template("devices", "show.html.erb", "<%= render('shared/fields') %><%= render('sibling') %>")
+    write_template("devices", "shared", "_fields.html.erb", "")
+    write_template("devices", "_sibling.html.erb", "[<%= template_name %>]")
+
+    expect(build_view(template: "devices/show").call.to_s).to eq "[devices/_sibling]"
+  end
+end


### PR DESCRIPTION
Look up bare-named partials in the directory containing the template that renders them, instead of a same-named directory at the root.

Previously, a partial rendered via a relative path (e.g. `render("shared/fields")` from `posts/show`) would look for its own bare-named partials under `shared/` at the root, rather than `posts/shared/`.