### PR TITLE
Prefer most specific partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 - Look up bare-named partials in the directory containing the template that renders them, instead of a same-named directory at the root. (@timriley in #282)
 
     Previously, a partial rendered via a relative path (e.g. `render("shared/fields")` from `posts/show`) would look for its own bare-named partials under `shared/` at the root, rather than `posts/shared/`.
+- Look up partials in the directory of the template rendering them before falling back to enclosing directories and then the root, instead of searching the root first. (@timriley in #283)
+
+    Previously, a partial at the root shadowed a same-named partial sitting alongside the template that rendered it. With both `_form.html.erb` and `posts/_form.html.erb` present, `render("form")` from `posts/show.html.erb` rendered the root `_form`; it now renders `posts/_form`.
+
+    This directory specificity outranks view path order, which now only matters when the same partial path exists across different view paths (earliest wins).
 
 ### Security
 

--- a/lib/hanami/view/renderer.rb
+++ b/lib/hanami/view/renderer.rb
@@ -10,7 +10,8 @@ module Hanami
     # Template lookup combines two pieces of state:
     #
     # - **`config.paths`** — the configured view paths, immutable for the lifetime of the
-    #   renderer. When multiple view paths are configured, earlier ones override later ones.
+    #   renderer. When multiple view paths are configured, earlier ones override later ones for the
+    #   same relative path.
     # - **`@prefixes`** — a stack of subdirectories within each view path to search, mutated
     #   during rendering. It starts at `[CURRENT_PATH_PREFIX]` (the root itself). When a template is
     #   rendered, its parent directory (e.g. `"users"` for `"users/index"`) is pushed onto the stack
@@ -18,11 +19,12 @@ module Hanami
     #   `users/index.html.erb`) can be found alongside the template that renders it. The stack is
     #   snapshot-and-restored around each render via `ensure`.
     #
-    # `#lookup` tries every combination of a path and a prefix, joining each pair with the
-    # requested name to find a matching file. `paths` are checked in configured order; an earlier
-    # entry overrides a later one. `prefixes` are checked oldest-first: a partial at the root
-    # wins over a same-named partial in a directory pushed onto the stack mid-render. First match
-    # wins.
+    # `#lookup` tries every combination of a prefix and a path, joining each pair with the
+    # requested name to find a matching file. `prefixes` are the outer loop, checked newest-first:
+    # the directory of the template currently rendering wins over the enclosing directories it was
+    # reached through, and the root is searched last. Within each prefix, `paths` are checked in
+    # configured order, so an earlier path overrides a later one for the same directory. First
+    # match wins.
     #
     # @api private
     class Renderer
@@ -94,8 +96,8 @@ module Hanami
       def lookup(name, format)
         View.cache.fetch_or_store(:lookup, name, format, config_data.object_id, prefixes) {
           catch :found do
-            config_data.paths.each do |path|
-              prefixes.each do |prefix|
+            prefixes.reverse_each do |prefix|
+              config_data.paths.each do |path|
                 file_path = path.lookup(prefix, name, format)
                 if file_path
                   relative_path = Pathname.new(file_path).relative_path_from(path.dir).to_s

--- a/spec/integration/template_rendering/partial_lookup_spec.rb
+++ b/spec/integration/template_rendering/partial_lookup_spec.rb
@@ -3,17 +3,16 @@
 RSpec.describe "Template rendering / Partial lookup" do
   let(:dir) { make_tmp_directory }
 
-  def build_view(template:, layout: false)
-    dir = self.dir
+  def build_view(template:, layout: false, paths: dir)
     Class.new(Hanami::View) {
-      config.paths = dir
+      config.paths = paths
       config.template = template
       config.layout = layout
     }.new
   end
 
-  def write_template(*segments, content)
-    path = File.join(dir, *segments)
+  def write_template(*segments, content, base: dir)
+    path = File.join(base, *segments)
     FileUtils.mkdir_p(File.dirname(path))
     File.write(path, content)
   end
@@ -59,5 +58,63 @@ RSpec.describe "Template rendering / Partial lookup" do
     write_template("devices", "_sibling.html.erb", "[<%= template_name %>]")
 
     expect(build_view(template: "devices/show").call.to_s).to eq "[devices/_sibling]"
+  end
+
+  describe "when the same partial name exists in more than one directory" do
+    it "prefers the partial in the directory of the template rendering it" do
+      write_template("_form.html.erb", "root[<%= template_name %>]")
+      write_template("posts", "_form.html.erb", "posts[<%= template_name %>]")
+      write_template("posts", "show.html.erb", "<%= render('form') %>")
+
+      expect(build_view(template: "posts/show").call.to_s).to eq "posts[posts/_form]"
+    end
+
+    it "falls back to the root when the template's own directory has no match" do
+      write_template("_form.html.erb", "root[<%= template_name %>]")
+      write_template("posts", "show.html.erb", "<%= render('form') %>")
+
+      expect(build_view(template: "posts/show").call.to_s).to eq "root[_form]"
+    end
+
+    it "prefers the deepest directory in the render chain" do
+      write_template("_form.html.erb", "root[<%= template_name %>]")
+      write_template("posts", "_form.html.erb", "posts[<%= template_name %>]")
+      write_template("posts", "comments", "_form.html.erb", "comments[<%= template_name %>]")
+      write_template("posts", "comments", "_list.html.erb", "<%= render('form') %>")
+      write_template("posts", "show.html.erb", "<%= render('comments/list') %>")
+
+      expect(build_view(template: "posts/show").call.to_s).to eq "comments[posts/comments/_form]"
+    end
+
+    it "walks outward through enclosing directories before reaching the root" do
+      write_template("_form.html.erb", "root[<%= template_name %>]")
+      write_template("posts", "_form.html.erb", "posts[<%= template_name %>]")
+      write_template("posts", "comments", "_list.html.erb", "<%= render('form') %>")
+      write_template("posts", "show.html.erb", "<%= render('comments/list') %>")
+
+      expect(build_view(template: "posts/show").call.to_s).to eq "posts[posts/_form]"
+    end
+
+    it "prefers a deeper directory in a later view path over the root of an earlier one" do
+      other_dir = make_tmp_directory
+
+      write_template("_form.html.erb", "first[<%= template_name %>]", base: other_dir)
+      write_template("posts", "_form.html.erb", "second[<%= template_name %>]")
+      write_template("posts", "show.html.erb", "<%= render('form') %>")
+
+      expect(build_view(template: "posts/show", paths: [other_dir, dir]).call.to_s)
+        .to eq "second[posts/_form]"
+    end
+
+    it "prefers an earlier view path when both hold the partial in the same directory" do
+      other_dir = make_tmp_directory
+
+      write_template("posts", "_form.html.erb", "first[<%= template_name %>]", base: other_dir)
+      write_template("posts", "_form.html.erb", "second[<%= template_name %>]")
+      write_template("posts", "show.html.erb", "<%= render('form') %>")
+
+      expect(build_view(template: "posts/show", paths: [other_dir, dir]).call.to_s)
+        .to eq "first[posts/_form]"
+    end
   end
 end


### PR DESCRIPTION
Look up partials in the directory of the template rendering them before falling back to enclosing directories and then the root, instead of searching the root first.

Previously, a partial at the root shadowed a same-named partial sitting alongside the template that rendered it. With both `_form.html.erb` and `posts/_form.html.erb` present, `render("form")` from `posts/show.html.erb` rendered the root `_form`; it now renders `posts/_form`.

This directory specificity outranks view path order, which now only matters when the same partial path exists across different view paths (earliest wins).